### PR TITLE
Implemented the _skip to_ expression (`->`)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,13 @@ The format of this *Change Log* is inspired by `keeapachangelog.org`_.
 ---------------
 .. _X.Y.Z: https://github.com/apalala/tatsu/compare/v4.1.1...master
 
+
+Added
+~~~~~
+
 *   Parse speeds on large files reduced by 5-20% by optimizing parse contexts and closures, and unifying the AST_ and CST_ stacks.
+
+*   Added the *"skip to"* expression, useful for writing *recovery* rules.  The parser will advance over input, one character at time, until the expression matches. Whitespace and comments will be skipped at each step.
 
 
 `4.1.1`_ @ 2017-05-21

--- a/docs/syntax.rst
+++ b/docs/syntax.rst
@@ -47,6 +47,12 @@ Expressions
 
 The expressions, in reverse order of operator precedence, can be:
 
+
+``# comment``
+^^^^^^^^^^^^^
+    `Python`_-style comments are allowed.
+
+
 ``e1 | e2``
 ^^^^^^^^^^^
     Choice. Match either ``e1`` or ``e2``.
@@ -247,6 +253,39 @@ The expressions, in reverse order of operator precedence, can be:
     Negative lookahead. Fail if ``e`` can be parsed, and do not consume any input.
 
 
+``->e``
+^^^^^^^
+    The *"skip to"* expression; useful for writing *recovery* rules.
+
+    The parser will advance over input, one character at time, until ``e`` matches. Whitespace and comments will be skipped at each step.
+
+    The expression is equivalent to:
+
+.. code:: ocaml
+
+    { /./ !e} e
+..
+
+    This is an example of the use of the _skip to_ expression for recovery:
+
+
+.. code:: ocaml
+
+        statement =
+            | if_statement
+            # ...
+            ;
+
+        if_statement
+            =
+            | 'if' condition 'then' statement ['else' statement]
+            | 'if' statement_recovery
+            ;
+
+        statement_recovery = ->&statement ;
+..
+
+
 ``'text'`` or ``"text"``
 ^^^^^^^^^^^^^^^^^^^^^^^^
     Match the token *text* within the quotation marks.
@@ -385,10 +424,6 @@ The expressions, in reverse order of operator precedence, can be:
 ^^^^^
     The *end of text* symbol. Verify that the end of the input text has been reached.
 
-
-``# comment``
-^^^^^^^^^^^^^
-    `Python`_-style comments are also allowed.
 
 When there are no named items in a rule, the `AST`_ consists of the
 elements parsed by the rule, either a single item or a ``list``. This

--- a/grammar/tatsu.ebnf
+++ b/grammar/tatsu.ebnf
@@ -198,8 +198,9 @@ term
     | closure
     | optional
     | special
-    | kif
-    | knot
+    | skip_to
+    | lookahead
+    | negative_lookahead
     | atom
     ;
 
@@ -302,15 +303,21 @@ special::Special
     ;
 
 
-kif::Lookahead
+lookahead::Lookahead
     =
     '&' ~ @:term
     ;
 
 
-knot::NegativeLookahead
+negative_lookahead::NegativeLookahead
     =
     '!' ~ @:term
+    ;
+
+
+skip_to::SkipTo
+    =
+    '->' ~ @:term
     ;
 
 

--- a/tatsu/bootstrap.py
+++ b/tatsu/bootstrap.py
@@ -492,9 +492,11 @@ class EBNFBootstrapParser(Parser):
             with self._option():
                 self._special_()
             with self._option():
-                self._kif_()
+                self._skip_to_()
             with self._option():
-                self._knot_()
+                self._lookahead_()
+            with self._option():
+                self._negative_lookahead_()
             with self._option():
                 self._atom_()
             self._error('no available options')
@@ -728,15 +730,22 @@ class EBNFBootstrapParser(Parser):
         self._cut()
 
     @tatsumasu('Lookahead')
-    def _kif_(self):  # noqa
+    def _lookahead_(self):  # noqa
         self._token('&')
         self._cut()
         self._term_()
         self.name_last_node('@')
 
     @tatsumasu('NegativeLookahead')
-    def _knot_(self):  # noqa
+    def _negative_lookahead_(self):  # noqa
         self._token('!')
+        self._cut()
+        self._term_()
+        self.name_last_node('@')
+
+    @tatsumasu('SkipTo')
+    def _skip_to_(self):  # noqa
+        self._token('->')
         self._cut()
         self._term_()
         self.name_last_node('@')
@@ -1041,10 +1050,13 @@ class EBNFBootstrapSemantics(object):
     def special(self, ast):  # noqa
         return ast
 
-    def kif(self, ast):  # noqa
+    def lookahead(self, ast):  # noqa
         return ast
 
-    def knot(self, ast):  # noqa
+    def negative_lookahead(self, ast):  # noqa
+        return ast
+
+    def skip_to(self, ast):  # noqa
         return ast
 
     def atom(self, ast):  # noqa

--- a/tatsu/codegen/python.py
+++ b/tatsu/codegen/python.py
@@ -258,6 +258,14 @@ class EmptyClosure(Base):
     template = 'self._empty_closure()'
 
 
+class SkipTo(Closure):
+    template = '''\
+                def block{n}():
+                {exp:1::}
+                self._skip_to(block{n})\
+    '''
+
+
 class Optional(_Decorator):
     template = '''\
                 with self._optional():

--- a/tatsu/contexts.py
+++ b/tatsu/contexts.py
@@ -232,6 +232,9 @@ class ParseContext(object):
     def _goto(self, pos):
         self._buffer.goto(pos)
 
+    def _next(self):
+        self._buffer.next()
+
     def _next_token(self, for_rule_name=None):
         if for_rule_name is None or for_rule_name.islower():
             self._buffer.next_token()
@@ -798,3 +801,13 @@ class ParseContext(object):
 
     def _void(self):
         self.last_node = None
+
+    def _skip_to(self, block):
+        while True:
+            self._next()
+            try:
+                with self._ifnot():
+                    block()
+            except FailedLookahead:
+                break
+        block()

--- a/tatsu/grammars.py
+++ b/tatsu/grammars.py
@@ -322,6 +322,14 @@ class NegativeLookahead(Decorator):
             super(NegativeLookahead, self).parse(ctx)
 
 
+class SkipTo(Decorator):
+    def parse(self, ctx):
+        return ctx._skip_to(lambda: super(SkipTo, self).parse(ctx))
+
+    def _to_str(self, lean=False):
+        return '->' + self.exp._to_ustr(lean=lean)
+
+
 class Sequence(Model):
     def __init__(self, ast, **kwargs):
         assert ast.sequence

--- a/test/grammar/lookahead_test.py
+++ b/test/grammar/lookahead_test.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+from tatsu.tool import compile
+
+
+class LookaheadTests(unittest.TestCase):
+    def test_skip_to(self, trace=False):
+        grammar = '''
+            start = 'x' ab $ ;
+            
+            ab 
+                =
+                | 'a' 'b'
+                | ->'a' 'b'
+                ;
+        '''
+        m = compile(grammar, trace=trace)
+        ast = m.parse('x xx yyy a b')
+        self.assertEqual(['x', ['a', 'b']], ast)
+
+        grammar = '''
+            start = 'x' ab $ ;
+            
+            ab 
+                =
+                | 'a' 'b'
+                | ->&'a' 'a' 'b'
+                ;
+        '''
+        m = compile(grammar, trace=trace)
+        ast = m.parse('x xx yyy a b')
+        self.assertEqual(['x', ['a', 'b']], ast)

--- a/test/grammar/lookahead_test.py
+++ b/test/grammar/lookahead_test.py
@@ -10,8 +10,8 @@ class LookaheadTests(unittest.TestCase):
     def test_skip_to(self, trace=False):
         grammar = '''
             start = 'x' ab $ ;
-            
-            ab 
+
+            ab
                 =
                 | 'a' 'b'
                 | ->'a' 'b'
@@ -23,8 +23,8 @@ class LookaheadTests(unittest.TestCase):
 
         grammar = '''
             start = 'x' ab $ ;
-            
-            ab 
+
+            ab
                 =
                 | 'a' 'b'
                 | ->&'a' 'a' 'b'


### PR DESCRIPTION
### ``->e``

The *"skip to"* expression; useful for writing *recovery* rules.

The parser will advance over input, one character at time, until ``e`` matches. Whitespace and comments will be skipped at each step.

The expression is equivalent to:

```ocaml
    { /./ !e} e
```
