### PR TITLE
[left_recursion_and_cut] memoization should not affect memoization results

### DIFF
--- a/docs/left_recursion.rst
+++ b/docs/left_recursion.rst
@@ -16,3 +16,30 @@ Left recursion support is enabled by default in |TatSu|. To disable it for a par
 
     @@left_recursion :: False
 
+
+.. warning::
+
+    Not all left-recursive grammars that use the |TatSu| syntax are PEG_. The same happens with right-recursive grammars.  **The order of rules in matters in PEG**.
+
+    For right-recursive grammars the choices that parse the most input must come first. The same is true  for left-recursive grammars.
+
+    Additionally, for grammars with **indirect left recursion, the rules containing choices must be the first invoked during a parse**. The following grammar is correct,but it will not work if the start rule is changed to ```start = mul ;```.
+
+    .. code:: ocaml
+
+            start = expr ;
+
+            expr
+                =
+                mul | identifier
+                ;
+
+            mul
+                =
+                expr '*' identifier
+                ;
+
+            identifier
+                =
+                /\w+/
+                ;

--- a/tatsu/contexts.py
+++ b/tatsu/contexts.py
@@ -330,7 +330,6 @@ class ParseContext(object):
             prune_dict(cache, lambda k, _: k[0] < cutpos)
 
         prune(self._memos, self._pos)
-        prune(self._results, self._pos)
 
     def _memoization(self):
         return self.memoize_lookaheads or self._lookahead == 0
@@ -464,7 +463,6 @@ class ParseContext(object):
 
     def _forget(self, key):
         self._memos.pop(key, None)
-        self._results.pop(key, None)
 
     def _memo_for(self, key):
         memo = self._memos.get(key)


### PR DESCRIPTION

*   The recursion logic takes care of cleaning up its caches. Having memoization
intervene produces unexpected results.

*   Document how not all left-recursive grammars that use the TatSu syntax are PEG-left.

closes #34