### PR TITLE
revert changes dropped input in left-recursion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,20 @@ The format of this *Change Log* is inspired by `keeapachangelog.org`_.
 .. _X.Y.Z: https://github.com/apalala/tatsu/compare/v4.2.1...master
 
 
+Fixed
+~~~~~
+
+*   `#27`_ Undo the fixes to dropped input on left recursion because they broke previous
+  expected behavior.
+
+*   `#33`_ Fixes to the calc example and mini tutorial (`@heronils`_)
+
+*   `#34`_ More left-recursion test cases (`@manueljacob`_).
+
+.. _#33: https://github.com/neogeny/TatSu/issues/33
+.. _#34: https://github.com/neogeny/TatSu/issues/34
+
+
 `4.2.1`_ @ 2017-06-18
 ---------------------
 .. _4.2.1: https://github.com/apalala/tatsu/compare/v4.2.0...v4.2.1
@@ -211,4 +225,4 @@ Added
 .. _neumond: https://bitbucket.org/neumond
 .. _pgebhard: https://bitbucket.org/pgebhard
 .. _siemer: https://bitbucket.org/siemer
-
+.. _@heronils: https://github.com/heronils

--- a/README.rst
+++ b/README.rst
@@ -104,11 +104,11 @@ This is an example of how to use |TatSu| as a library:
         from tatsu import parse
 
         ast = parse(GRAMMAR, '3 + 5 * ( 10 - 20 )')
-        print('PPRINT')
+        print('# PPRINT')
         pprint.pprint(ast, indent=2, width=20)
         print()
 
-        print('JSON')
+        print('# JSON')
         print(json.dumps(ast.asjson(), indent=2))
         print()
 ..

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -17,6 +17,7 @@ features, bug fixes, or suggestions:
     `Manuel Jacob`_,
     `Marcus Brinkmann`_,
     `Max Liebkies`_,
+    `Nils-Hero Lindemann`_,
     `Paul Houle`_,
     `Paul Sargent`_,
     `Robert Speer`_,
@@ -47,6 +48,7 @@ Most of the contributions are recorded as **Grako** commits_ or issues_.
 .. _Manuel Jacob: https://github.com/manueljacob
 .. _Marcus Brinkmann: https://bitbucket.org/lambdafu/
 .. _Max Liebkies: https://bitbucket.org/gegenschall
+.. _Nils-Hero Lindemann: https://github.com/heronils
 .. _Paul Houle: https://github.com/paulhoule
 .. _Paul Sargent: https://bitbucket.org/pauls
 .. _Robert Speer: https://bitbucket.org/r_speer

--- a/docs/mini-tutorial.rst
+++ b/docs/mini-tutorial.rst
@@ -145,13 +145,13 @@ We can now compile the grammar, and test the parser:
         parser = tatsu.compile(grammar)
         ast = parser.parse('3 + 5 * ( 10 - 20 )')
 
-        print('SIMPLE PARSE')
-        print('AST')
+        print('# SIMPLE PARSE')
+        print('# AST')
         pprint(ast, width=20, indent=4)
 
         print()
 
-        print('JSON')
+        print('# JSON')
         print(json.dumps(ast, indent=4))
 
 
@@ -601,16 +601,16 @@ The model that results from a parse can be printed, and walked:
         def walk_object(self, node):
             return node
 
-        def walk_add(self, node):
+        def walk__add(self, node):
             return self.walk(node.left) + self.walk(node.right)
 
-        def walk_subtract(self, node):
+        def walk__subtract(self, node):
             return self.walk(node.left) - self.walk(node.right)
 
-        def walk_multiply(self, node):
+        def walk__multiply(self, node):
             return self.walk(node.left) * self.walk(node.right)
 
-        def walk_divide(self, node):
+        def walk__divide(self, node):
             return self.walk(node.left) / self.walk(node.right)
 
 
@@ -705,8 +705,11 @@ The code generator can be used thus:
         print(postfix)
 
 
-Which results in::
+Which results in:
 
+.. code:: python
+
+    # TRANSLATED TO POSTFIX
     PUSH 3
     PUSH 5
     PUSH 10

--- a/examples/calc/calc.py
+++ b/examples/calc/calc.py
@@ -16,8 +16,9 @@ def simple_parse():
     grammar = open('grammars/calc_cut.ebnf').read()
 
     parser = tatsu.compile(grammar)
-    ast = parser.parse('3 + 5 * ( 10 - 20 )', trace=True, colorize=True)
+    ast = parser.parse('3 + 5 * ( 10 - 20 )', trace=False, colorize=True)
 
+    print()
     print('# SIMPLE PARSE')
     print('# AST')
     pprint(ast, width=20, indent=4)
@@ -34,6 +35,7 @@ def annotated_parse():
     parser = tatsu.compile(grammar)
     ast = parser.parse('3 + 5 * ( 10 - 20 )')
 
+    print()
     print('# ANNOTATED AST')
     pprint(ast, width=20, indent=4)
     print()
@@ -68,13 +70,15 @@ def parse_with_basic_semantics():
     grammar = open('grammars/calc_annotated.ebnf').read()
 
     parser = tatsu.compile(grammar)
-    ast = parser.parse(
+    result = parser.parse(
         '3 + 5 * ( 10 - 20 )',
         semantics=CalcBasicSemantics()
     )
 
+    print()
     print('# BASIC SEMANTICS RESULT')
-    pprint(ast, width=20, indent=4)
+    assert result == -47
+    print(result)
     print()
 
 
@@ -104,6 +108,7 @@ def parse_factored():
         semantics=CalcSemantics()
     )
 
+    print()
     print('# FACTORED SEMANTICS RESULT')
     pprint(ast, width=20, indent=4)
     print()
@@ -115,6 +120,7 @@ def parse_to_model():
     parser = tatsu.compile(grammar, asmodel=True)
     model = parser.parse('3 + 5 * ( 10 - 20 )')
 
+    print()
     print('# MODEL TYPE IS:', type(model).__name__)
     print(json.dumps(model.asjson(), indent=4))
     print()
@@ -124,16 +130,16 @@ class CalcWalker(NodeWalker):
     def walk_object(self, node):
         return node
 
-    def walk_add(self, node):
+    def walk__add(self, node):
         return self.walk(node.left) + self.walk(node.right)
 
-    def walk_subtract(self, node):
+    def walk__subtract(self, node):
         return self.walk(node.left) - self.walk(node.right)
 
-    def walk_multiply(self, node):
+    def walk__multiply(self, node):
         return self.walk(node.left) * self.walk(node.right)
 
-    def walk_divide(self, node):
+    def walk__divide(self, node):
         return self.walk(node.left) / self.walk(node.right)
 
 
@@ -143,8 +149,11 @@ def parse_and_walk_model():
     parser = tatsu.compile(grammar, asmodel=True)
     model = parser.parse('3 + 5 * ( 10 - 20 )')
 
+    print()
     print('# WALKER RESULT')
-    print(CalcWalker().walk(model))
+    result = CalcWalker().walk(model)
+    assert result == -47
+    print(result)
     print()
 
 
@@ -156,6 +165,7 @@ def parse_and_translate():
 
     postfix = PostfixCodeGenerator().render(model)
 
+    print()
     print('# TRANSLATED TO POSTFIX')
     print(postfix)
 


### PR DESCRIPTION
*   #27 Undo the fixes to dropped input on left recursion because they broke previously expected behavior.

*   #33 Fixes to the calc example and mini tutorial (@heronils)

*   #34 More left-recursion test cases (@manueljacob).
