### PR TITLE
Regression fix: including file does not work because EBNFBuffer is not used

### DIFF
--- a/tatsu/parser.py
+++ b/tatsu/parser.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from tatsu.bootstrap import EBNFBootstrapParser
 from tatsu.semantics import ASTSemantics
 from tatsu.parser_semantics import EBNFGrammarSemantics
+from tatsu.grammars import EBNFBuffer
 
 
 class EBNFParser(EBNFBootstrapParser):
@@ -20,5 +21,6 @@ class GrammarGenerator(EBNFBootstrapParser):
         super(GrammarGenerator, self).__init__(
             semantics=semantics,
             parseinfo=parseinfo,
+            buffer_class=EBNFBuffer,
             **kwargs
         )


### PR DESCRIPTION
This is most likely some kind of regression but I didn't bother checking when it occurred. Note that this didn't work in Grako for some time now, aswell.

Including files via the pragma does not work, because the `GrammarGenerator` that subclasses `EBNFBootstrapParser` does not use the `EBNFBuffer` class as its `buffer_class` but the default one from the parent class constructor. The default one lacks the ability to include files.

These two commits provide a test case (more of an integration test) and a fix for that.

Cheers!