### PR TITLE
Updated use.rst because json.dumps raised error

### DIFF
--- a/docs/use.rst
+++ b/docs/use.rst
@@ -247,7 +247,7 @@ passing the grammar to parse and the starting rule's name as parameter:
     parser = MyParser()
     ast = parser.parse('text to parse', rule_name='start')
     print(ast)
-    print(json.dumps(ast, indent=2)) # ASTs are JSON-friendy
+    print(json.dumps(asjson(ast), indent=2))
 
 The generated parsers' constructors accept named arguments to specify
 whitespace characters, the regular expression for comments, case


### PR DESCRIPTION
The json.dumps line in "Using the Tool" section of Tatsu docs do not reflect the line in the README. An error was raised (raise TypeError(repr(o) + " is not JSON serializable")) when using json.dumps without asjson(). Updating that line to the code in README now works as intended.