### PR TITLE
[start_symbol] make parsers use the first rule in the grammar as default start rule

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,14 @@ The format of this *Change Log* is inspired by `keeapachangelog.org`_.
 .. _X.Y.Z: https://github.com/apalala/tatsu/compare/v4.2.3...master
 
 
+Fixed
+~~~~~
+
+*   `#40`_ Make the start rule default to the first rule defined in the grammar (`@hariedo`_).
+
+.. _#40: https://github.com/neogeny/TatSu/issues/40
+
+
 `4.2.3`_ @ 2017-07-10
 ---------------------
 .. _4.2.3: https://github.com/apalala/tatsu/compare/v4.2.2...v4.2.3
@@ -248,3 +256,4 @@ Added
 .. _pgebhard: https://bitbucket.org/pgebhard
 .. _siemer: https://bitbucket.org/siemer
 .. _@heronils: https://github.com/heronils
+.. _@hariedo: https://github.com/hariedo

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,9 @@ This is an example of how to use |TatSu| as a library:
         print()
 ..
 
-And this is the output:
+|TatSu| will use the first rule defined in the grammar as the *start* rule.
+
+This is the output:
 
 .. code:: console
 

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -12,7 +12,7 @@ As a Library
 
     Compiles the grammar and generates a *model* that can subsequently be used for parsing input with.
 
--   ``tatsu.parse(grammar, input, **kwargs)``
+-   ``tatsu.parse(grammar, input, start=None, **kwargs)``
 
     Compiles the grammar and parses the given input producing an AST_ as result. The result is equivalent to calling::
 

--- a/tatsu/codegen/python.py
+++ b/tatsu/codegen/python.py
@@ -448,6 +448,7 @@ class Grammar(Base):
             keywords = '\n%s\n' % keywords
 
         fields.update(rules=indent(rules),
+                      start=self.node.rules[0].name,
                       abstract_rules=abstract_rules,
                       version=version,
                       whitespace=whitespace,
@@ -555,14 +556,14 @@ class Grammar(Base):
                 {abstract_rules}
 
 
-                def main(filename, startrule, **kwargs):
+                def main(filename, start='{start}', **kwargs):
                     if not filename or filename == '-':
                         text = sys.stdin.read()
                     else:
                         with open(filename) as f:
                             text = f.read()
                     parser = {name}Parser()
-                    return parser.parse(text, startrule, filename=filename, **kwargs)
+                    return parser.parse(text, start=start, filename=filename, **kwargs)
 
 
                 if __name__ == '__main__':
@@ -575,5 +576,5 @@ class Grammar(Base):
                     print()
                     print('JSON:')
                     print(json.dumps(asjson(ast), indent=2))
-                    print()
+                    print()\
                 '''

--- a/tatsu/tool.py
+++ b/tatsu/tool.py
@@ -147,9 +147,9 @@ def compile(grammar, name=None, semantics=None, asmodel=False, **kwargs):
     return model
 
 
-def parse(grammar, input, name=None, semantics=None, asmodel=False, **kwargs):
+def parse(grammar, input, start=None, name=None, semantics=None, asmodel=False, **kwargs):
     model = compile(grammar, name=name, semantics=semantics, asmodel=asmodel, **kwargs)
-    return model.parse(input, semantics=semantics, **kwargs)
+    return model.parse(input, start=start, semantics=semantics, **kwargs)
 
 
 def to_python_sourcecode(grammar, name=None, filename=None, **kwargs):

--- a/tatsu/util.py
+++ b/tatsu/util.py
@@ -324,7 +324,7 @@ def generic_main(custom_main, parser_class, name='Unknown'):
            metavar="STARTRULE",
            nargs='?',
            help="the start rule for parsing",
-           default='start')
+           default=None)
 
     args = argp.parse_args()
     try:


### PR DESCRIPTION

*   previously 'start' was forced upon generated parsers
*   also make the `start=` argument to `parse()` explicit in the docs

fixes #40