### PR TITLE
Import 're' from tatsu.util to support optional 'regex'-only features

### DIFF
--- a/tatsu/parser_semantics.py
+++ b/tatsu/parser_semantics.py
@@ -2,12 +2,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from collections import OrderedDict
-import re
 
 from tatsu import grammars
 from tatsu.exceptions import FailedSemantics
 from tatsu.semantics import ModelBuilderSemantics
-from tatsu.util import eval_escapes, warning
+from tatsu.util import eval_escapes, re, warning
 
 
 class EBNFGrammarSemantics(ModelBuilderSemantics):


### PR DESCRIPTION
See issue #42