### PR TITLE
Fix runtime error in example

### DIFF
--- a/docs/use.rst
+++ b/docs/use.rst
@@ -73,7 +73,7 @@ This is an example of how to use **Tatsu** as a library:
         print()
 
         print('JSON')
-        print(json.dumps(ast.asjson(), indent=2))
+        print(json.dumps(ast, indent=2))
         print()
 
 


### PR DESCRIPTION
I get this error with the example as written:

```
PPRINT
[ '3',
  '+',
  [ '5',
    '*',
    [ '10',
      '-',
      '20']]]

JSON
Traceback (most recent call last):
  File "able3.py", line 47, in <module>
    main()
  File "able3.py", line 42, in main
    print(json.dumps(ast.asjson(), indent=2))
AttributeError: 'list' object has no attribute 'asjson'
```