### PR TITLE
Only care about case of first letter of rule name

### DIFF
--- a/tatsu/contexts.py
+++ b/tatsu/contexts.py
@@ -235,7 +235,7 @@ class ParseContext(object):
         return self._buffer.next()
 
     def _next_token(self, ruleinfo=None):
-        if ruleinfo is None or ruleinfo.name.islower():
+        if ruleinfo is None or ruleinfo.name[0].islower():
             self._buffer.next_token()
 
     @property

--- a/test/parsing_test.py
+++ b/test/parsing_test.py
@@ -76,6 +76,23 @@ class ParsingTests(unittest.TestCase):
         ast = tatsu.parse(grammar, "test", rule_name='start')
         self.assertEqual(ast, "test")
 
+    def test_rule_capitalization(self):
+        grammar = '''
+            start = ['test' {rulename}] ;
+            {rulename} = /[a-zA-Z0-9]+/ ;
+        '''
+        test_string = 'test 12'
+        lowercase_rule_names = ['nocaps', 'camelCase', 'tEST']
+        uppercase_rule_names = ['Capitalized', 'CamelCase', 'TEST']
+        ref_lowercase_result = tatsu.parse(grammar.format(rulename='reflowercase'), test_string, rule_name='start')
+        ref_uppercase_result = tatsu.parse(grammar.format(rulename='Refuppercase'), test_string, rule_name='start')
+        for rulename in lowercase_rule_names:
+            result = tatsu.parse(grammar.format(rulename=rulename), test_string, rule_name='start')
+            self.assertEqual(result, ref_lowercase_result)
+        for rulename in uppercase_rule_names:
+            result = tatsu.parse(grammar.format(rulename=rulename), test_string, rule_name='start')
+            self.assertEqual(result, ref_uppercase_result)
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromTestCase(ParsingTests)


### PR DESCRIPTION
According to the documentation in docs/syntax.rst, rule names that start with an uppercase character do not advance over whitespace before beginning to parse. Currently, there are some issues in the implementation of this.

Right now the logic checks to see if the entire rule name is lowercase before advancing over whitespace. This pull request fixes it so it only checks the first letter. It looks like this bug originally came from here: https://github.com/neogeny/TatSu/commit/3f57ab620f35ccd27746372e53a8c6c0e6ddb3a7#diff-db601756bf2cb00180df4b281f5bcf9aL490

This can be tested with the following test:
```python
import tatsu

def make_test_grammar( rule_name, rule_syntax ):
    grammar_template = "start = 'hello' %s $ ; %s = %s ;"
    return grammar_template % (rule_name, rule_name, rule_syntax)

text = 'hello world'
rule_names = 'WORLDRULE', 'Wordrule', 'wordRule', 'wordrule'
rule_syntaxes = "'world'", '/[a-zA-Z]+/'

for rule_syntax in rule_syntaxes:
    for rule_name in rule_names:
        try:
            grammar = make_test_grammar( rule_name, rule_syntax )
            print('grammar: ' + grammar)
            result = tatsu.parse(grammar, text)
            print(rule_name + ' -> ' + str(result))
        except:
            print(rule_name + ' -> FAILED')
```

Before this fix, the parsing results for `worldRule` matched the parsing results for the grammars with uppercase rule-names. After the fix, `worldRule` matches the parsing results for `worldrule`. 

_(Note: If you run the code above, when the rule syntax is `'world'` instead of the regex, it looks like Worldrule (and all other uppercase variants) are skipping over whitespace. I'm not sure, but it looks like a bug to me.)_
