### PR TITLE
Fix the RST syntax of two headlines

### DIFF
--- a/docs/syntax.rst
+++ b/docs/syntax.rst
@@ -687,7 +687,7 @@ Both patterns may also be specified within a grammar using the
     @@eol_comments :: /#.*?$/
 
 Reserved Words and Keywords
-~~~~~~~~~~~~~~~~~~~~~~~~~~-
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some languages must reserve the use of certain tokens as valid
 identifiers because the tokens are used to mark particular constructs in
@@ -723,7 +723,7 @@ use of the token:
     statements = {!'END' statement}+ ;
 
 Include Directive
-~~~~~~~~~~~~~~~~-
+~~~~~~~~~~~~~~~~~
 
 |TatSu| grammars support file inclusion through the include directive:
 


### PR DESCRIPTION
Fix the RST headline markup of "Reserved Words and Keywords" and " Include
Directive". This typo made these two sections not visible in the table of
contents.