### PR TITLE
Eliminate undocumented 'asmodel' parameter from tutorials

### DIFF
--- a/docs/mini-tutorial.rst
+++ b/docs/mini-tutorial.rst
@@ -595,6 +595,7 @@ The model that results from a parse can be printed, and walked:
 .. code:: python
 
     from tatsu.walkers import NodeWalker
+    from tatsu.semantics import ModelBuilderSemantics
 
 
     class CalcWalker(NodeWalker):
@@ -617,7 +618,7 @@ The model that results from a parse can be printed, and walked:
     def parse_and_walk_model():
         grammar = open('grammars/calc_model.ebnf').read()
 
-        parser = tatsu.compile(grammar, asmodel=True)
+        parser = tatsu.compile(grammar, semantics=ModelBuilderSemantics())
         model = parser.parse('3 + 5 * ( 10 - 20 )')
 
         print('# WALKER RESULT IS:')
@@ -696,7 +697,7 @@ The code generator can be used thus:
     def parse_and_translate():
         grammar = open('grammars/calc_model.ebnf').read()
 
-        parser = tatsu.compile(grammar, asmodel=True)
+        parser = tatsu.compile(grammar, semantics=ModelBuilderSemantics())
         model = parser.parse('3 + 5 * ( 10 - 20 )')
 
         postfix = PostfixCodeGenerator().render(model)

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -41,6 +41,8 @@ You can also use `Python`_'s built-in types as node types, and
 default behavior can be overidden by defining a method to handle the
 result of any particular grammar rule.
 
+The flag `asmodel=True` is an obsolete synonym for `semantics=ModelBuilderSemantics()`.
+
 Walking Models
 ~~~~~~~~~~~~~~
 

--- a/examples/calc/calc.py
+++ b/examples/calc/calc.py
@@ -8,6 +8,7 @@ from pprint import pprint
 import tatsu
 from tatsu.ast import AST
 from tatsu.walkers import NodeWalker
+from tatsu.semantics import ModelBuilderSemantics
 
 from codegen import PostfixCodeGenerator
 
@@ -117,7 +118,7 @@ def parse_factored():
 def parse_to_model():
     grammar = open('grammars/calc_model.ebnf').read()
 
-    parser = tatsu.compile(grammar, asmodel=True)
+    parser = tatsu.compile(grammar, semantics=ModelBuilderSemantics())
     model = parser.parse('3 + 5 * ( 10 - 20 )')
 
     print()
@@ -146,7 +147,7 @@ class CalcWalker(NodeWalker):
 def parse_and_walk_model():
     grammar = open('grammars/calc_model.ebnf').read()
 
-    parser = tatsu.compile(grammar, asmodel=True)
+    parser = tatsu.compile(grammar, semantics=ModelBuilderSemantics())
     model = parser.parse('3 + 5 * ( 10 - 20 )')
 
     print()
@@ -160,7 +161,7 @@ def parse_and_walk_model():
 def parse_and_translate():
     grammar = open('grammars/calc_model.ebnf').read()
 
-    parser = tatsu.compile(grammar, asmodel=True)
+    parser = tatsu.compile(grammar, semantics=ModelBuilderSemantics())
     model = parser.parse('3 + 5 * ( 10 - 20 )')
 
     postfix = PostfixCodeGenerator().render(model)


### PR DESCRIPTION
It is equivalent to `semantics=tatsu.ModelBuilderSemantics()`, which
is documented; replace it with that everywhere.

Also document it, for historical reasons.