### PR TITLE
[docs] contributing: update link s/bitbucket/github

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -3,9 +3,9 @@
 Contributing
 ------------
 
-|TatSu| development is done on Bitbucket_. Bug reports, patches, suggestions, and improvements are welcome.
+|TatSu| development is done on github_. Bug reports, patches, suggestions, and improvements are welcome.
 
-.. _bitbucket : https://bitbucket.org/neogeny/tatsu/
+.. _github : https://github.com/neogeny/TatSu
 
 
 Donations


### PR DESCRIPTION
a tiny edit to a tiny doc file.

i'm guessing some time after the transition from Grako to TatSu, hosting of the repository changed from bitbucket to github. but nonetheless there remains an old link pointing to a nonexistent bitbucket repository. hopefully this updated link is the correct, "official" link for contributing. Thanks!