### PR TITLE
parse_with_basic_semantics -> semantics

### DIFF
--- a/docs/mini-tutorial.rst
+++ b/docs/mini-tutorial.rst
@@ -305,7 +305,7 @@ Semantics for |TatSu| parsers are not specified in the grammar, but in a separat
         parser = tatsu.compile(grammar)
         ast = parser.parse(
             '3 + 5 * ( 10 - 20 )',
-            parse_with_basic_semantics=CalcBasicSemantics()
+            semantics=CalcBasicSemantics()
         )
 
         print('# BASIC SEMANTICS RESULT')


### PR DESCRIPTION
There is no `parse_with_basic_semantics` honoured by `tatsu.compile()`, only `semantics` is honoured.

This PR fixes the error in the documentation.