### PR TITLE
Fix typo in command-line help

### DIFF
--- a/docs/use.rst
+++ b/docs/use.rst
@@ -163,7 +163,7 @@ The *-h* and *--help* parameters provide full usage information:
 
     generation options:
     --no-left-recursion, -l
-                            turns left-recusion support off
+                            turns left-recursion support off
     --name NAME, -m NAME  Name for the grammar (defaults to GRAMMAR base name)
     --no-nameguard, -n    allow tokens that are prefixes of others
     --outfile FILE, --output FILE, -o FILE

--- a/tatsu/tool.py
+++ b/tatsu/tool.py
@@ -79,7 +79,7 @@ def parse_args():
     generation_opts = argparser.add_argument_group('generation options')
     generation_opts.add_argument(
         '--no-left-recursion', '-l',
-        help='turns left-recusion support off',
+        help='turns left-recursion support off',
         dest="left_recursion",
         action='store_false',
         default=True,


### PR DESCRIPTION
Change "left-recusion" to "left-recursion".