### PR TITLE
Fix errors in Makefile for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ cython:
 
 
 clean: clean_cython
-	find -name "__pycache__" | xargs rm -rf
-	find -name "*.pyc" | xargs rm -f
-	find -name "*.pyd" | xargs rm -f
-	find -name "*.pyo" | xargs rm -f
-	find -name "*.orig" | xargs rm -f
+	find . -name "__pycache__" | xargs rm -rf
+	find . -name "*.pyc" | xargs rm -f
+	find . -name "*.pyd" | xargs rm -f
+	find . -name "*.pyo" | xargs rm -f
+	find . -name "*.orig" | xargs rm -f
 	rm -rf tatsu.egg-info
 	rm -rf dist
 	rm -rf build


### PR DESCRIPTION
The `find` command on BSD variants requires a path before any find expression.