### PR TITLE
[nameguard] fix @@nameguard not being honored

### DIFF
--- a/tatsu/buffering.py
+++ b/tatsu/buffering.py
@@ -44,14 +44,13 @@ class Buffer(object):
         self.comments_re = comments_re
         self.eol_comments_re = eol_comments_re
         self.ignorecase = ignorecase
-        self.nameguard = (nameguard
-                          if nameguard is not None
-                          else bool(self.whitespace_re))
+        self.nameguard = (
+            nameguard if nameguard is not None
+            else bool(self.whitespace_re) or bool(namechars)
+        )
         self.comment_recovery = comment_recovery
-        self.namechars = namechars
-        self._namechar_set = set(namechars)
-        if namechars:
-            self.nameguard = True
+        self.namechars = namechars if namechars is not None else ''
+        self._namechar_set = set(self.namechars)
 
         self._pos = 0
         self._len = 0

--- a/tatsu/tool.py
+++ b/tatsu/tool.py
@@ -167,7 +167,7 @@ def compile(grammar, name=None, semantics=None, asmodel=False, **kwargs):
 
 
 def parse(grammar, input, start=None, name=None, semantics=None, asmodel=False, **kwargs):
-    model = compile(grammar, name=name, semantics=semantics, asmodel=asmodel, **kwargs)
+    model = compile(grammar, name=name, semantics=semantics, asmodel=asmodel)
     return model.parse(input, start=start, semantics=semantics, **kwargs)
 
 

--- a/test/grammar/directive_test.py
+++ b/test/grammar/directive_test.py
@@ -134,3 +134,18 @@ class DirectiveTests(unittest.TestCase):
         code = codegen(model)
         self.assertTrue('parseinfo=False' in code)
         compile(code, 'test.py', EXEC)
+
+    def test_nameguard_directive(self):
+        GRAMMAR = '''
+            @@grammar :: test
+            @@nameguard :: False
+            @@namechars :: ''
+
+            start = sequence $ ;
+            sequence = {digit}+ ;
+            digit = 'x' | '1' | '2' | '3' | '4' | '5' ;
+        '''
+
+        model = tatsu.compile(GRAMMAR)
+        self.assertEquals(['2', '3'], model.parse('23'))
+        self.assertEquals(['x', 'x'], model.parse('xx'))

--- a/test/grammar/directive_test.py
+++ b/test/grammar/directive_test.py
@@ -147,5 +147,6 @@ class DirectiveTests(unittest.TestCase):
         '''
 
         model = tatsu.compile(GRAMMAR)
+        self.assertFalse(model.nameguard)
         self.assertEquals(['2', '3'], model.parse('23'))
         self.assertEquals(['x', 'x'], model.parse('xx'))


### PR DESCRIPTION
In the multiple passing of settings between parser layers, the value of `@@nameguard` was not making it to the `Buffer` class.

fixes #95