### PR TITLE
[py3] remove explicit support for Python < 3.5 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ workflows:
       - test-3.7
       - test-3.6
       - test-3.5
-      - test-pypy
 
 jobs:
   test-3.7:  &test-template
@@ -76,47 +75,6 @@ jobs:
     docker:
       - image: circleci/python:3.5
 
-  test-pypy  :
-    docker:
-      - image: circleci/python:3.7
-
-    working_directory: ~/repo-pypy
-
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "requirements-test.txt" }}
-          - v1-dependencies-
-
-      - run:
-          name: install dependencies
-          command: |
-            sudo apt update
-            sudo apt install -y python-pip
-            sudo apt install -y virtualenv
-            sudo apt install -y pypy
-            virtualenv venv -p pypy
-            . venv/bin/activate
-            pip install -U pip
-            pip install -r requirements-test.txt
-
-      - save_cache:
-          paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements-test.txt" }}
-
-      - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            flake8
-            py.test
-
-      - store_artifacts:
-          path: test-reports
-          destination: test-reports
 
   test-pypy3  :
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ workflows:
       - test-3.7
       - test-3.6
       - test-3.5
-      - test-2.7
       - test-pypy
 
 jobs:
@@ -76,49 +75,6 @@ jobs:
     <<: *test-template
     docker:
       - image: circleci/python:3.5
-
-  test-2.7:
-    docker:
-      - image: circleci/python:2.7
-
-    working_directory: ~/repo27
-
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "requirements-test.txt" }}
-          - v1-dependencies-
-
-      - run:
-          name: install dependencies
-          command: |
-            sudo apt update
-            sudo apt install -y python-pip
-            sudo apt install -y virtualenv
-            sudo apt install -y pypy
-            virtualenv venv -p python2.7
-            . venv/bin/activate
-            pip install -U pip
-            pip install -r requirements-test.txt
-
-      - save_cache:
-          paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements-test.txt" }}
-
-      - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            flake8
-            py.test
-
-      - store_artifacts:
-          path: test-reports
-          destination: test-reports
-
 
   test-pypy  :
     docker:

--- a/examples/calc/calc.py
+++ b/examples/calc/calc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import json
 from codecs import open

--- a/examples/calc/codegen.py
+++ b/examples/calc/codegen.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import sys
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cython>=0.29
+#Cython>=0.29
 colorama>=0.4
 docutils>=0.14
 flake8>=3.6

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setuptools.setup(
         'Intended Audience :: Science/Research',
         'Environment :: Console',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import sys
+import sys  # noqa
 import io
 import setuptools
 import tatsu

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,12 @@ SHORT_DESCRIPTION = (
 ).format(toolname=NAME)
 
 
-try:
-    from Cython.Build import cythonize
-except ImportError:
-    CYTHON = False
-else:
-    CYTHON = 'bdist_wheel' not in sys.argv
+# try:
+#     from Cython.Build import cythonize
+# except ImportError:
+#     CYTHON = False
+# else:
+#     CYTHON = 'bdist_wheel' not in sys.argv
 
 setuptools.setup(
     zip_safe=False,
@@ -58,7 +58,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy',
-        'Programming Language :: Cython',
+        # 'Programming Language :: Cython',
         'Topic :: Software Development :: Code Generators',
         'Topic :: Software Development :: Compilers',
         'Topic :: Software Development :: Interpreters',
@@ -70,15 +70,15 @@ setuptools.setup(
     extras_require={
         'future-regex': ['regex']
     },
-    ext_modules=cythonize(
-        "tatsu/**/*.py",
-        exclude=[
-            'tatsu/__main__.py',
-            'tatsu/__init__.py',
-            'tatsu/codegen/__init__.py',
-            'tatsu/test/__main__.py',
-            'tatsu/test/*.py'
-        ],
-        language_level=2,
-    ) if CYTHON else [],
+    # ext_modules=cythonize(
+    #     "tatsu/**/*.py",
+    #     exclude=[
+    #         'tatsu/__main__.py',
+    #         'tatsu/__init__.py',
+    #         'tatsu/codegen/__init__.py',
+    #         'tatsu/test/__main__.py',
+    #         'tatsu/test/*.py'
+    #     ],
+    #     language_level=2,
+    # ) if CYTHON else [],
 )

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: Implementation :: PyPy',
+        'Programming Language :: Python :: Implementation :: PyPy3',
         # 'Programming Language :: Cython',
         'Topic :: Software Development :: Code Generators',
         'Topic :: Software Development :: Compilers',

--- a/tatsu/__init__.py
+++ b/tatsu/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from tatsu._config import __version__
 from tatsu._config import __toolname__

--- a/tatsu/__main__.py
+++ b/tatsu/__main__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 import tatsu
 
 if __name__ == '__main__':

--- a/tatsu/_config.py
+++ b/tatsu/_config.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 __toolname__ = 'TatSu'
-__version__ = '4.4.0'
+__version__ = '5.5.0a1'

--- a/tatsu/_unicode_characters.py
+++ b/tatsu/_unicode_characters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from tatsu.util import is_posix
 

--- a/tatsu/ast.py
+++ b/tatsu/ast.py
@@ -3,7 +3,7 @@
 Define the AST class, a direct descendant of dict that's used during parsing
 to store the values of named elements of grammar rules.
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from tatsu.util import strtype, asjson, is_list, PY3, Mapping
 

--- a/tatsu/ast.py
+++ b/tatsu/ast.py
@@ -4,8 +4,9 @@ Define the AST class, a direct descendant of dict that's used during parsing
 to store the values of named elements of grammar rules.
 """
 from __future__ import generator_stop
+from collections.abc import Mapping
 
-from tatsu.util import strtype, asjson, is_list, PY3, Mapping
+from tatsu.util import asjson, is_list
 
 
 class AST(dict):
@@ -27,23 +28,11 @@ class AST(dict):
     def iterkeys(self):
         return iter(self)
 
-    def keys(self):
-        keys = self.iterkeys()
-        return keys if PY3 else list(keys)
-
-    def itervalues(self):
+    def values(self):
         return (self[k] for k in self)
 
-    def values(self):
-        values = self.itervalues()
-        return values if PY3 else list(values)
-
-    def iteritems(self):
-        return ((k, self[k]) for k in self)
-
     def items(self):
-        items = self.iteritems()
-        return items if PY3 else list(items)
+        return ((k, self[k]) for k in self)
 
     def update(self, *args, **kwargs):
         def upairs(d):
@@ -113,7 +102,7 @@ class AST(dict):
         return self[name]
 
     def __hasattribute__(self, name):
-        if not isinstance(name, strtype):
+        if not isinstance(name, str):
             return False
         try:
             super(AST, self).__getattribute__(name)

--- a/tatsu/bootstrap.py
+++ b/tatsu/bootstrap.py
@@ -11,7 +11,7 @@
 # the file is generated.
 
 
-from __future__ import print_function, division, absolute_import, unicode_literals
+from __future__ import generator_stop
 
 import sys
 

--- a/tatsu/buffering.py
+++ b/tatsu/buffering.py
@@ -11,7 +11,7 @@ from __future__ import generator_stop
 import os
 from itertools import takewhile, repeat
 
-from tatsu.util import identity, imap, ustr, strtype
+from tatsu.util import identity
 from tatsu.util import extend_list, contains_sublist
 from tatsu.util import re as regexp
 from tatsu.util import RETYPE, WHITESPACE_RE
@@ -34,7 +34,7 @@ class Buffer(object):
                  comment_recovery=False,
                  namechars='',
                  **kwargs):
-        text = ustr(text)
+        text = str(text)
         self.text = self.original_text = text
         self.filename = filename or ''
 
@@ -79,7 +79,7 @@ class Buffer(object):
         elif isinstance(whitespace, RETYPE):
             return whitespace
         elif whitespace:
-            if not isinstance(whitespace, strtype):
+            if not isinstance(whitespace, str):
                 # a list or a set?
                 whitespace = ''.join(c for c in whitespace)
             return regexp.compile(
@@ -242,7 +242,7 @@ class Buffer(object):
 
     def _eat_regex(self, regex):
         if regex is not None:
-            return list(takewhile(identity, imap(self.matchre, repeat(regex))))
+            return list(takewhile(identity, map(self.matchre, repeat(regex))))
 
     def eat_whitespace(self):
         return self._eat_regex(self.whitespace_re)

--- a/tatsu/buffering.py
+++ b/tatsu/buffering.py
@@ -6,8 +6,7 @@ Line analysis and caching are done so the parser can freely move with goto(p)
 to any position in the parsed text, and still recover accurate information
 about source lines and content.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import generator_stop
 
 import os
 from itertools import takewhile, repeat

--- a/tatsu/codegen/__init__.py
+++ b/tatsu/codegen/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from tatsu.exceptions import CodegenError
 from tatsu.codegen.cgbase import (  # noqa

--- a/tatsu/codegen/cgbase.py
+++ b/tatsu/codegen/cgbase.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from tatsu.objectmodel import Node
 from tatsu.exceptions import CodegenError

--- a/tatsu/codegen/objectmodel.py
+++ b/tatsu/codegen/objectmodel.py
@@ -17,7 +17,6 @@ from tatsu.objectmodel import BASE_CLASS_TOKEN
 from tatsu.exceptions import CodegenError
 from tatsu.rendering import Renderer
 from tatsu.codegen.cgbase import ModelRenderer, CodeGenerator
-from tatsu.util import PY33
 
 
 NODE_NAME_PATTERN = r'(?!\d)\w+(' + BASE_CLASS_TOKEN + r'(?!\d)\w+)*'
@@ -70,10 +69,7 @@ def _get_full_name(cls):
         raise CodegenError("Base type has to be inside a module")
     modulename = module.__name__
 
-    if PY33:
-        name = cls.__qualname__
-    else:
-        name = cls.__name__
+    name = cls.__qualname__
 
     # Try to reference the class
     try:
@@ -91,6 +87,7 @@ def _get_full_name(cls):
 
 class BaseTypeRenderer(Renderer):
     def __init__(self, base_type):
+        super().__init__()
         self.base_type = base_type
 
     def render_fields(self, fields):

--- a/tatsu/codegen/objectmodel.py
+++ b/tatsu/codegen/objectmodel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import inspect
 
@@ -220,7 +220,7 @@ class Grammar(ModelRenderer):
                 # Any changes you make to it will be overwritten the next time
                 # the file is generated.
 
-                from __future__ import print_function, division, absolute_import, unicode_literals
+                from __future__ import generator_stop
 
                 from tatsu.objectmodel import Node
                 from tatsu.semantics import ModelBuilderSemantics

--- a/tatsu/codegen/python.py
+++ b/tatsu/codegen/python.py
@@ -9,8 +9,6 @@ from tatsu.util import (
     safe_name,
     trim,
     timestamp,
-    urepr,
-    ustr,
     compress_seq,
     RETYPE
 )
@@ -56,7 +54,7 @@ class Fail(Base):
 class Comment(Base):
     def render_fields(self, fields):
         lines = '\n'.join(
-            '# %s' % ustr(c) for c in self.node.comment.splitlines()
+            '# %s' % str(c) for c in self.node.comment.splitlines()
         )
         fields.update(lines=lines)
 
@@ -84,21 +82,21 @@ class Group(_Decorator):
 
 class Token(Base):
     def render_fields(self, fields):
-        fields.update(token=urepr(self.node.token))
+        fields.update(token=repr(self.node.token))
 
     template = "self._token({token})"
 
 
 class Constant(Base):
     def render_fields(self, fields):
-        fields.update(literal=urepr(self.node.literal))
+        fields.update(literal=repr(self.node.literal))
 
     template = "self._constant({literal})"
 
 
 class Pattern(Base):
     def render_fields(self, fields):
-        raw_repr = urepr(self.node.pattern)
+        raw_repr = repr(self.node.pattern)
         fields.update(pattern=raw_repr)
 
     template = 'self._pattern({pattern})'
@@ -140,7 +138,7 @@ class Choice(Base):
             error = 'no available options'
         fields.update(n=self.counter(),
                       options=indent(options),
-                      error=urepr(error)
+                      error=repr(error)
                       )
 
     def render(self, **fields):
@@ -334,9 +332,9 @@ class Rule(_Decorator):
     @staticmethod
     def param_repr(p):
         if isinstance(p, (int, float)):
-            return ustr(p)
+            return str(p)
         else:
-            return urepr(p.split(BASE_CLASS_TOKEN)[0])
+            return repr(p.split(BASE_CLASS_TOKEN)[0])
 
     def render_fields(self, fields):
         self.reset_counter()
@@ -369,8 +367,8 @@ class Rule(_Decorator):
         if not (sdefs or ldefs):
             sdefines = ''
         else:
-            sdefs = '[%s]' % ', '.join(urepr(d) for d in sorted(sdefs))
-            ldefs = '[%s]' % ', '.join(urepr(d) for d in sorted(ldefs))
+            sdefs = '[%s]' % ', '.join(repr(d) for d in sorted(sdefs))
+            ldefs = '[%s]' % ', '.join(repr(d) for d in sorted(ldefs))
             if not ldefs:
                 sdefines = '\n\n    self.ast._define(%s, %s)' % (sdefs, ldefs)
             else:
@@ -425,24 +423,24 @@ class Grammar(Base):
         if not whitespace:
             whitespace = 'None'
         elif isinstance(whitespace, RETYPE):
-            whitespace = urepr(whitespace)
+            whitespace = repr(whitespace)
         else:
-            whitespace = 're.compile({0})'.format(urepr(whitespace))
+            whitespace = 're.compile({0})'.format(repr(whitespace))
 
         if self.node.nameguard is not None:
-            nameguard = urepr(self.node.nameguard)
+            nameguard = repr(self.node.nameguard)
         elif self.node.directives.get('nameguard') is not None:
             nameguard = self.node.directives.get('nameguard')
         else:
             nameguard = 'None'
 
-        comments_re = urepr(self.node.directives.get('comments'))
-        eol_comments_re = urepr(self.node.directives.get('eol_comments'))
+        comments_re = repr(self.node.directives.get('comments'))
+        eol_comments_re = repr(self.node.directives.get('eol_comments'))
         ignorecase = self.node.directives.get('ignorecase', 'None')
         left_recursion = self.node.directives.get('left_recursion', True)
         parseinfo = self.node.directives.get('parseinfo', True)
 
-        namechars = urepr(self.node.directives.get('namechars') or '')
+        namechars = repr(self.node.directives.get('namechars') or '')
 
         rules = '\n'.join([
             self.get_renderer(rule).render() for rule in self.node.rules
@@ -450,7 +448,7 @@ class Grammar(Base):
 
         version = str(tuple(int(n) for n in str(timestamp()).split('.')))
 
-        keywords = '\n'.join("    %s," % urepr(k) for k in sorted(self.keywords))
+        keywords = '\n'.join("    %s," % repr(k) for k in sorted(self.keywords))
         if keywords:
             keywords = '\n%s\n' % keywords
 

--- a/tatsu/codegen/python.py
+++ b/tatsu/codegen/python.py
@@ -2,7 +2,7 @@
 """
 Python code generation for models defined with tatsu.model
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from tatsu.util import (
     indent,
@@ -488,7 +488,7 @@ class Grammar(Base):
                 # the file is generated.
 
 
-                from __future__ import print_function, division, absolute_import, unicode_literals
+                from __future__ import generator_stop
 
                 import sys
 

--- a/tatsu/color.py
+++ b/tatsu/color.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 
 class _BF(object):

--- a/tatsu/containers.py
+++ b/tatsu/containers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import copy
 from collections import OrderedDict

--- a/tatsu/contexts.py
+++ b/tatsu/contexts.py
@@ -12,7 +12,7 @@ from ._unicode_characters import (
     C_FAILURE,
     C_RECURSION,
 )
-from tatsu.util import notnone, ustr, prune_dict, is_list, info, safe_name
+from tatsu.util import notnone, prune_dict, is_list, info, safe_name
 from tatsu.util import left_assoc, right_assoc
 from tatsu.util import debug  # noqa
 from tatsu import buffering
@@ -383,7 +383,7 @@ class ParseContext(object):
     def _trace(self, msg, *params, **kwargs):
         if self.trace:
             msg = msg % params
-            info(ustr(msg), file=sys.stderr)
+            info(str(msg), file=sys.stderr)
 
     def _trace_event(self, event):
         if self.trace:
@@ -599,7 +599,7 @@ class ParseContext(object):
                 self._memoize(key, result)
                 return result
             except FailedSemantics as e:
-                self._error(ustr(e), FailedParse)
+                self._error(str(e), FailedParse)
             finally:
                 self._pop_ast()
         except FailedParse as e:
@@ -838,7 +838,7 @@ class ParseContext(object):
         return self.cst
 
     def _check_name(self):
-        name = ustr(self.last_node)
+        name = str(self.last_node)
         if self.ignorecase or self._buffer.ignorecase:
             name = name.upper()
         if name in self.keywords:

--- a/tatsu/contexts.py
+++ b/tatsu/contexts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals  # noqa
+from __future__ import generator_stop
 
 import sys
 import functools

--- a/tatsu/diagrams.py
+++ b/tatsu/diagrams.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import itertools
 

--- a/tatsu/exceptions.py
+++ b/tatsu/exceptions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from tatsu.util import re
 

--- a/tatsu/g2e/__init__.py
+++ b/tatsu/g2e/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals  # noqa
+from __future__ import generator_stop
 
 import codecs
 import sys

--- a/tatsu/g2e/__main__.py
+++ b/tatsu/g2e/__main__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from . import main
 

--- a/tatsu/g2e/semantics.py
+++ b/tatsu/g2e/semantics.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import generator_stop
 
 import re
 from itertools import chain

--- a/tatsu/grammars.py
+++ b/tatsu/grammars.py
@@ -8,7 +8,7 @@ from copy import copy
 from itertools import takewhile
 
 from tatsu.util import (
-    indent, trim, ustr, urepr, strtype, compress_seq, chunks,
+    indent, trim, compress_seq, chunks,
     re, notnone,
 )
 from tatsu.exceptions import FailedRef, GrammarError
@@ -175,9 +175,6 @@ class Model(Node):
     def _to_str(self, lean=False):
         return '%s:%d' % (type(self).__name__, id(self))
 
-    def _to_ustr(self, lean=False):
-        return ustr(self._to_str(lean=lean))
-
     def __str__(self):
         return self._to_str()
 
@@ -260,7 +257,7 @@ class Decorator(Model):
         return 1 + self.exp.nodecount()
 
     def _to_str(self, lean=False):
-        return self.exp._to_ustr(lean=lean)
+        return self.exp._to_str(lean=lean)
 
     def _nullable(self):
         return Nullable.of(self.exp)
@@ -280,7 +277,7 @@ class Group(Decorator):
             return ctx.last_node
 
     def _to_str(self, lean=False):
-        exp = self.exp._to_ustr(lean=lean)
+        exp = self.exp._to_str(lean=lean)
         if len(exp.splitlines()) > 1:
             return '(\n%s\n)' % indent(exp)
         else:
@@ -299,7 +296,7 @@ class Token(Model):
         return {(self.token,)}
 
     def _to_str(self, lean=False):
-        return urepr(self.token)
+        return repr(self.token)
 
 
 class Constant(Model):
@@ -311,7 +308,7 @@ class Constant(Model):
         return self.literal
 
     def _to_str(self, lean=False):
-        return '`%s`' % urepr(self.literal)
+        return '`%s`' % repr(self.literal)
 
     def _nullable(self):
         return True
@@ -337,7 +334,7 @@ class Pattern(Model):
 
     def _to_str(self, lean=False):
         parts = []
-        for pat in (ustr(p) for p in self.patterns):
+        for pat in (str(p) for p in self.patterns):
             template = '/%s/'
             if '/' in pat:
                 template = '?"%s"'
@@ -355,7 +352,7 @@ class Lookahead(Decorator):
             super(Lookahead, self).parse(ctx)
 
     def _to_str(self, lean=False):
-        return '&' + self.exp._to_ustr(lean=lean)
+        return '&' + self.exp._to_str(lean=lean)
 
     def _nullable(self):
         return True
@@ -367,7 +364,7 @@ class NegativeLookahead(Decorator):
             super(NegativeLookahead, self).parse(ctx)
 
     def _to_str(self, lean=False):
-        return '!' + ustr(self.exp._to_str(lean=lean))
+        return '!' + str(self.exp._to_str(lean=lean))
 
     def _nullable(self):
         return True
@@ -378,7 +375,7 @@ class SkipTo(Decorator):
         return ctx._skip_to(lambda: super(SkipTo, self).parse(ctx))
 
     def _to_str(self, lean=False):
-        return '->' + self.exp._to_ustr(lean=lean)
+        return '->' + self.exp._to_str(lean=lean)
 
 
 class Sequence(Model):
@@ -416,7 +413,7 @@ class Sequence(Model):
 
     def _to_str(self, lean=False):
         comments = self.comments_str()
-        seq = [ustr(s._to_str(lean=lean)) for s in self.sequence]
+        seq = [str(s._to_str(lean=lean)) for s in self.sequence]
         single = ' '.join(seq)
         if len(single) <= PEP8_LLEN and len(single.splitlines()) <= 1:
             return comments + single
@@ -436,7 +433,7 @@ class Sequence(Model):
 class Choice(Model):
     def __init__(self, ast=None, **kwargs):
         super(Choice, self).__init__(ast=AST(options=ast))
-        assert isinstance(self.options, list), urepr(self.options)
+        assert isinstance(self.options, list), repr(self.options)
 
     def parse(self, ctx):
         with ctx._choice():
@@ -445,7 +442,7 @@ class Choice(Model):
                     ctx.last_node = o.parse(ctx)
                     return ctx.last_node
 
-            lookahead = ' '.join(ustr(urepr(f[0])) for f in self.lookahead() if str(f))
+            lookahead = ' '.join(str(repr(f[0])) for f in self.lookahead() if str(f))
             if lookahead:
                 ctx._error('expecting one of {%s}' % lookahead)
             ctx._error('no available options')
@@ -471,7 +468,7 @@ class Choice(Model):
         return 1 + sum(o.nodecount() for o in self.options)
 
     def _to_str(self, lean=False):
-        options = [ustr(o._to_str(lean=lean)) for o in self.options]
+        options = [str(o._to_str(lean=lean)) for o in self.options]
 
         multi = any(len(o.splitlines()) > 1 for o in options)
         single = ' | '.join(o for o in options)
@@ -502,7 +499,7 @@ class Closure(Decorator):
         return {()} | result
 
     def _to_str(self, lean=False):
-        sexp = ustr(self.exp._to_str(lean=lean))
+        sexp = str(self.exp._to_str(lean=lean))
         if len(sexp.splitlines()) <= 1:
             return '{%s}' % sexp
         else:
@@ -551,7 +548,7 @@ class Join(Decorator):
 
     def _to_str(self, lean=False):
         ssep = self.sep._to_str(lean=lean)
-        sexp = ustr(self.exp._to_str(lean=lean))
+        sexp = str(self.exp._to_str(lean=lean))
         if len(sexp.splitlines()) <= 1:
             return '%s%s{%s}' % (ssep, self.JOINOP, sexp)
         else:
@@ -625,7 +622,7 @@ class Optional(Decorator):
         return {()} | self.exp._first(k, f)
 
     def _to_str(self, lean=False):
-        exp = ustr(self.exp._to_str(lean=lean))
+        exp = str(self.exp._to_str(lean=lean))
         template = '[%s]'
         if isinstance(self.exp, Choice):
             template = trim(self.str_template)
@@ -673,8 +670,8 @@ class Named(Decorator):
 
     def _to_str(self, lean=False):
         if lean:
-            return self.exp._to_ustr(lean=True)
-        return '%s:%s' % (self.name, self.exp._to_ustr(lean=lean))
+            return self.exp._to_str(lean=True)
+        return '%s:%s' % (self.name, self.exp._to_str(lean=lean))
 
 
 class NamedList(Named):
@@ -688,8 +685,8 @@ class NamedList(Named):
 
     def _to_str(self, lean=False):
         if lean:
-            return self.exp._to_ustr(lean=True)
-        return '%s+:%s' % (self.name, ustr(self.exp._to_str(lean=lean)))
+            return self.exp._to_str(lean=True)
+        return '%s+:%s' % (self.name, str(self.exp._to_str(lean=lean)))
 
 
 class Override(Named):
@@ -755,7 +752,7 @@ class RuleRef(Model):
 
 class RuleInclude(Decorator):
     def __init__(self, rule):
-        assert isinstance(rule, Rule), ustr(rule.name)
+        assert isinstance(rule, Rule), str(rule.name)
         super(RuleInclude, self).__init__(rule.exp)
         self.rule = rule
 
@@ -812,11 +809,11 @@ class Rule(Decorator):
     @staticmethod
     def param_repr(p):
         if isinstance(p, (int, float)):
-            return ustr(p)
-        elif isinstance(p, strtype) and p.isalnum():
-            return ustr(p)
+            return str(p)
+        elif isinstance(p, str) and p.isalnum():
+            return str(p)
         else:
-            return urepr(p)
+            return repr(p)
 
     def _to_str(self, lean=False):
         comments = self.comments_str()
@@ -844,7 +841,7 @@ class Rule(Decorator):
                 else:
                     params = '(%s)' % params
 
-        base = ' < %s' % ustr(self.base.name) if self.base else ''
+        base = ' < %s' % str(self.base.name) if self.base else ''
 
         return trim(self.str_template).format(
             name=self.name,
@@ -1056,8 +1053,8 @@ class Grammar(Model):
                 name=directive,
                 frame='/' if directive in regex_directives else '',
                 value=(
-                    urepr(value) if directive in string_directives
-                    else ustr(value) if directive in ustr_directives
+                    repr(value) if directive in string_directives
+                    else str(value) if directive in ustr_directives
                     else value
                 ),
             )
@@ -1066,13 +1063,13 @@ class Grammar(Model):
             directives += '\n'
 
         keywords = '\n'.join(
-            '@@keyword :: ' + ' '.join(urepr(k) for k in c if k is not None)
+            '@@keyword :: ' + ' '.join(repr(k) for k in c if k is not None)
             for c in chunks(sorted(self.keywords), 8)
         ).strip()
         keywords = '\n\n' + keywords + '\n' if keywords else ''
 
         rules = (
-            '\n\n'.join(ustr(rule._to_str(lean=lean))
+            '\n\n'.join(str(rule._to_str(lean=lean))
                         for rule in self.rules)
         ).rstrip() + '\n'
         return directives + keywords + rules

--- a/tatsu/grammars.py
+++ b/tatsu/grammars.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import os
 import functools

--- a/tatsu/infos.py
+++ b/tatsu/infos.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from collections import namedtuple
 

--- a/tatsu/leftrec.py
+++ b/tatsu/leftrec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from collections import defaultdict
 import tatsu.grammars

--- a/tatsu/model.py
+++ b/tatsu/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from tatsu.ast import AST                           # noqa: F401
 from tatsu.objectmodel import Node                  # noqa: F401

--- a/tatsu/objectmodel.py
+++ b/tatsu/objectmodel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 
 import collections

--- a/tatsu/objectmodel.py
+++ b/tatsu/objectmodel.py
@@ -3,10 +3,10 @@ from __future__ import generator_stop
 
 
 import collections
+from collections.abc import Mapping, MutableMapping
 import weakref
 
 from tatsu.util import asjson, asjsons
-from tatsu.util import Mapping, MutableMapping
 from tatsu.infos import CommentInfo
 from tatsu.ast import AST
 # TODO: from tatsu.exceptions import NoParseInfo

--- a/tatsu/parser.py
+++ b/tatsu/parser.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from tatsu.bootstrap import EBNFBootstrapParser
 from tatsu.semantics import ASTSemantics

--- a/tatsu/parser_semantics.py
+++ b/tatsu/parser_semantics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from collections import OrderedDict
 

--- a/tatsu/parsing.py
+++ b/tatsu/parsing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from tatsu.exceptions import FailedRef
 from tatsu.contexts import ParseContext, tatsumasu, leftrec, nomemo  # noqa

--- a/tatsu/rendering.py
+++ b/tatsu/rendering.py
@@ -3,8 +3,7 @@
 The Renderer class provides the infrastructure for generating template-based
 code. It's used by the .grammars module for parser generation.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import generator_stop
 
 import itertools
 import string

--- a/tatsu/rendering.py
+++ b/tatsu/rendering.py
@@ -8,7 +8,7 @@ from __future__ import generator_stop
 import itertools
 import string
 
-from tatsu.util import indent, isiter, strtype, trim, ustr
+from tatsu.util import indent, isiter, trim
 
 
 def render(item, join='', **fields):
@@ -16,7 +16,7 @@ def render(item, join='', **fields):
     """
     if item is None:
         return ''
-    elif isinstance(item, strtype):
+    elif isinstance(item, str):
         return item
     elif isinstance(item, Renderer):
         return item.render(join=join, **fields)
@@ -25,7 +25,7 @@ def render(item, join='', **fields):
     elif isinstance(item, (int, float)):
         return item
     else:
-        return ustr(item)
+        return str(item)
 
 
 class RenderingFormatter(string.Formatter):

--- a/tatsu/semantics.py
+++ b/tatsu/semantics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 from tatsu.util import simplify_list
 from tatsu.util import builtins

--- a/tatsu/semantics.py
+++ b/tatsu/semantics.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import generator_stop
 
+import builtins
 from tatsu.util import simplify_list
-from tatsu.util import builtins
 from tatsu.exceptions import SemanticError
 from tatsu.objectmodel import Node
 from tatsu.objectmodel import BASE_CLASS_TOKEN

--- a/tatsu/symtables.py
+++ b/tatsu/symtables.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import weakref
 from copy import copy

--- a/tatsu/tool.py
+++ b/tatsu/tool.py
@@ -3,7 +3,7 @@
 Parse and translate an EBNF grammar into a Python parser for
 the described language.
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 import codecs
 import argparse
 import os

--- a/tatsu/util.py
+++ b/tatsu/util.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import sys
 import os

--- a/tatsu/yaml.py
+++ b/tatsu/yaml.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, division, absolute_import, unicode_literals
+from __future__ import generator_stop
 
 # This code was copied from post from coldfix in Stack Overflow:
 #

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 
 def main():

--- a/test/ast_test.py
+++ b/test/ast_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/buffering_test.py
+++ b/test/buffering_test.py
@@ -3,8 +3,7 @@
 Tests for consistency of the line information caches kept by
 tatsu.buffering.Buffer.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import generator_stop
 
 import os
 import random

--- a/test/buffering_test.py
+++ b/test/buffering_test.py
@@ -12,7 +12,6 @@ from codecs import open
 
 from tatsu import parse
 from tatsu.buffering import Buffer
-from tatsu.util import ustr
 
 
 class BufferingTests(unittest.TestCase):
@@ -20,7 +19,7 @@ class BufferingTests(unittest.TestCase):
     def setUp(self):
         testfile = os.path.splitext(__file__)[0] + '.py'
         with open(testfile, encoding='utf-8') as f:
-            self.text = ustr(f.read())
+            self.text = str(f.read())
         self.buf = Buffer(self.text, whitespace='')
 
     def test_pos_consistency(self):

--- a/test/codegen_test.py
+++ b/test/codegen_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/diagram_test.py
+++ b/test/diagram_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function, unicode_literals)
+from __future__ import generator_stop
 
 import sys
 import unittest

--- a/test/grammar/directive_test.py
+++ b/test/grammar/directive_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/grammar/join_test.py
+++ b/test/grammar/join_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/grammar/keyword_test.py
+++ b/test/grammar/keyword_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/grammar/left_recursion_test.py
+++ b/test/grammar/left_recursion_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/grammar/lookahead_test.py
+++ b/test/grammar/lookahead_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/grammar/parameter_test.py
+++ b/test/grammar/parameter_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/grammar/parameter_test.py
+++ b/test/grammar/parameter_test.py
@@ -5,7 +5,7 @@ import unittest
 
 from tatsu.parser import GrammarGenerator
 from tatsu.tool import compile
-from tatsu.util import trim, ustr, PY3
+from tatsu.util import trim
 from tatsu.codegen import codegen
 
 
@@ -32,7 +32,7 @@ class ParameterTests(unittest.TestCase):
                 ;
         '''
         model = compile(grammar, "test")
-        self.assertEqual(trim(grammar), ustr(model))
+        self.assertEqual(trim(grammar), str(model))
 
     def test_36_params_and_keyword_params(self):
         grammar = '''
@@ -42,7 +42,7 @@ class ParameterTests(unittest.TestCase):
                 ;
         '''
         model = compile(grammar, "test")
-        self.assertEqual(trim(grammar), ustr(model))
+        self.assertEqual(trim(grammar), str(model))
 
     def test_36_param_combinations(self):
         def assert_equal(target, value):
@@ -120,7 +120,7 @@ class ParameterTests(unittest.TestCase):
         '''
 
         model = compile(grammar, 'RuleArguments')
-        self.assertEqual(trim(pretty), ustr(model))
+        self.assertEqual(trim(pretty), str(model))
         model = compile(pretty, 'RuleArguments')
 
         ast = model.parse("a b c")
@@ -196,25 +196,13 @@ class ParameterTests(unittest.TestCase):
                 =
                 'a'
                 ;
-        '''
-        rule2 = '''
 
-            rulé::Añez
-                =
-                '\\xf1'
-                ;
-        '''
-        rule3 = '''
 
             rúlé::Añez
                 =
                 'ñ'
                 ;
         '''
-        if PY3:
-            grammar += rule3
-        else:
-            grammar += rule2
 
         model = compile(grammar, "test")
-        self.assertEqual(trim(grammar), ustr(model))
+        self.assertEqual(trim(grammar), str(model))

--- a/test/grammar/pattern_test.py
+++ b/test/grammar/pattern_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/grammar/pattern_test.py
+++ b/test/grammar/pattern_test.py
@@ -3,7 +3,7 @@ from __future__ import generator_stop
 
 import unittest
 
-from tatsu.util import trim, urepr
+from tatsu.util import trim
 from tatsu.tool import compile
 from tatsu.exceptions import FailedParse
 from tatsu.codegen import codegen
@@ -117,7 +117,7 @@ class PatternTests(unittest.TestCase):
         print(codegen(model.rules[0].exp.sequence[0]))
         self.assertEqual(
             codegen(model.rules[0].exp.sequence[0]),
-            urepr("self._pattern('(?x)\nfoo\nbar\n')").strip('"\'')
+            repr("self._pattern('(?x)\nfoo\nbar\n')").strip('"\'')
         )
 
         grammar = r'''
@@ -129,5 +129,5 @@ class PatternTests(unittest.TestCase):
         print(codegen(model.rules[0].exp.sequence[0]))
         self.assertEqual(
             trim(codegen(model.rules[0].exp.sequence[0])),
-            urepr("self._pattern('(?x)foo\\nbar\nblort')").strip(r'"\.')
+            repr("self._pattern('(?x)foo\\nbar\nblort')").strip(r'"\.')
         )

--- a/test/grammar/pretty_test.py
+++ b/test/grammar/pretty_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/grammar/semantics_test.py
+++ b/test/grammar/semantics_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/grammar/stateful_test.py
+++ b/test/grammar/stateful_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/grammar/syntax_test.py
+++ b/test/grammar/syntax_test.py
@@ -5,7 +5,7 @@ import unittest
 
 from tatsu.exceptions import FailedParse
 from tatsu.tool import compile
-from tatsu.util import trim, ustr
+from tatsu.util import trim
 from tatsu.codegen import codegen
 from tatsu.grammars import EBNFBuffer
 
@@ -220,7 +220,7 @@ class SyntaxTests(unittest.TestCase):
         model = compile(grammar, "test")
         ast = model.parse("abb", nameguard=False)
         self.assertEqual(['a', 'b', 'b'], ast)
-        self.assertEqual(trim(grammar), ustr(model))
+        self.assertEqual(trim(grammar), str(model))
 
     def test_rule_include(self):
         grammar = '''

--- a/test/grammar/syntax_test.py
+++ b/test/grammar/syntax_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import unittest
 

--- a/test/parsing_test.py
+++ b/test/parsing_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import generator_stop
 
 import unittest
 import tempfile

--- a/test/zzz_bootstrap/bootstrap_test.py
+++ b/test/zzz_bootstrap/bootstrap_test.py
@@ -2,8 +2,7 @@
 """
 This awkward set of tests tries to make the tool bang its head against iself.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import generator_stop
 
 import json
 import os

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, pypy, pypy3, cython
+envlist = py35, py36, py37, py38, pypy, pypy3, cython
 
 [testenv]
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, pypy, pypy3, cython
+envlist = py35, py36, py37, py38, pypy, pypy3
 
 [testenv]
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ deps =
 commands =
     flake8
     mypy . --ignore-missing-imports
-    mypy . --py2 --ignore-missing-imports
     py.test
 
 deps =
@@ -31,7 +30,6 @@ deps =
 commands =
     flake8
     mypy . --ignore-missing-imports
-    mypy . --py2 --ignore-missing-imports
     py.test
 
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, pypy, pypy3
+envlist = py35, py36, py37, py38, pypy3
 
 [testenv]
 whitelist_externals =


### PR DESCRIPTION
* All unit tests pass
* Tested with parsers for Java, COBOL, and Oracle SQL
* Cython tests supended until Cython 3

closes #99 