### PR TITLE
Replaced imports from `collections` to `collections.abc` for python 3.8

### DIFF
--- a/tatsu/containers.py
+++ b/tatsu/containers.py
@@ -3,7 +3,7 @@ from __future__ import generator_stop
 
 import copy
 from collections import OrderedDict
-from collections import Callable
+from collections.abc import Callable
 
 
 # Source: http://stackoverflow.com/a/6190500/562769

--- a/tatsu/grammars.py
+++ b/tatsu/grammars.py
@@ -3,7 +3,8 @@ from __future__ import generator_stop
 
 import os
 import functools
-from collections import defaultdict, Mapping
+from collections.abc import Mapping
+from collections import defaultdict
 from copy import copy
 from itertools import takewhile
 


### PR DESCRIPTION
In python 3.8 classes from `collections.abc` cannot be imported by importing from
`collections`. Therefore some imports needed to be changed.