### PR TITLE
Implement the @nomemo decorator for grammar rules

### DIFF
--- a/grammar/tatsu.ebnf
+++ b/grammar/tatsu.ebnf
@@ -101,7 +101,7 @@ rule::Rule
 
 decorator
     =
-    '@' !'@' ~ @:('override'|'name')
+    '@' !'@' ~ @:('override'|'name'|'nomemo')
     ;
 
 

--- a/tatsu/bootstrap.py
+++ b/tatsu/bootstrap.py
@@ -17,7 +17,7 @@ import sys
 
 from tatsu.buffering import Buffer
 from tatsu.parsing import Parser
-from tatsu.parsing import tatsumasu
+from tatsu.parsing import tatsumasu, leftrec, nomemo
 from tatsu.parsing import leftrec, nomemo  # noqa
 from tatsu.util import re, generic_main  # noqa
 
@@ -340,6 +340,8 @@ class EBNFBootstrapParser(Parser):
                     self._token('override')
                 with self._option():
                     self._token('name')
+                with self._option():
+                    self._token('nomemo')
                 self._error('no available options')
         self.name_last_node('@')
 

--- a/tatsu/codegen/python.py
+++ b/tatsu/codegen/python.py
@@ -512,7 +512,7 @@ class Grammar(Base):
                         namechars={namechars},
                         **kwargs
                     ):
-                        super({name}Buffer, self).__init__(
+                        super().__init__(
                             text,
                             whitespace=whitespace,
                             nameguard=nameguard,
@@ -541,7 +541,7 @@ class Grammar(Base):
                     ):
                         if keywords is None:
                             keywords = KEYWORDS
-                        super({name}Parser, self).__init__(
+                        super().__init__(
                             whitespace=whitespace,
                             nameguard=nameguard,
                             comments_re=comments_re,

--- a/tatsu/grammars.py
+++ b/tatsu/grammars.py
@@ -778,7 +778,7 @@ class Rule(Decorator):
         self.is_name = 'name' in self.decorators
         self.base = None
         self.is_leftrec = False  # Starts a left recursive cycle
-        self.is_memoizable = True  # False if part of a left recursive cycle
+        self.is_memoizable = 'nomemo' not in self.decorators
 
     def parse(self, ctx):
         result = self._parse_rhs(ctx, self.exp)


### PR DESCRIPTION
Grammar rules have the `is_memoizable` attribute profuct of the implementation of leftrec.

These changes expose the attribute as a grammar decorator for rules.