### PR TITLE
[ast] make the result of sequences be `tuple`

### DIFF
--- a/tatsu/contexts.py
+++ b/tatsu/contexts.py
@@ -608,7 +608,7 @@ class ParseContext(object):
     def _get_node(self, pos, ruleinfo):
         node = self.ast
         if not node:
-            node = self.cst
+            node = tuple(self.cst) if is_list(self.cst) else self.cst
         elif '@' in node:
             node = node['@']  # override the AST
         elif self.parseinfo:

--- a/tatsu/grammars.py
+++ b/tatsu/grammars.py
@@ -384,7 +384,7 @@ class SkipTo(Decorator):
 class Sequence(Model):
     def __init__(self, ast, **kwargs):
         assert ast.sequence
-        self.sequence = []
+        self.sequence = ()
         super().__init__(ast=ast)
 
     def parse(self, ctx):

--- a/tatsu/parser_semantics.py
+++ b/tatsu/parser_semantics.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import generator_stop
 
-from tatsu import grammars
-from tatsu.exceptions import FailedSemantics
-from tatsu.semantics import ModelBuilderSemantics
-from tatsu.util import eval_escapes, re, warning, flatten
+from collections.abc import Sequence
+
+from . import grammars
+from .exceptions import FailedSemantics
+from .semantics import ModelBuilderSemantics
+from .util import eval_escapes, re, warning, flatten
 
 
 class EBNFGrammarSemantics(ModelBuilderSemantics):
@@ -63,7 +65,7 @@ class EBNFGrammarSemantics(ModelBuilderSemantics):
 
     def sequence(self, ast, *args):
         seq = ast.sequence
-        assert isinstance(seq, list), str(seq)
+        assert isinstance(seq, Sequence), str(seq)
         if len(seq) == 1:
             return seq[0]
         return grammars.Sequence(ast)

--- a/test/grammar/directive_test.py
+++ b/test/grammar/directive_test.py
@@ -91,27 +91,9 @@ class DirectiveTests(unittest.TestCase):
         """)
 
         expected = [
-            [
-                [
-                    "a",
-                    "b"
-                ],
-                "\n"
-            ],
-            [
-                [
-                    "c",
-                    "d"
-                ],
-                "\n"
-            ],
-            [
-                [
-                    "e",
-                    "f"
-                ],
-                "\n"
-            ]
+            (["a", "b"], "\n"),
+            (["c", "d"], "\n"),
+            (["e", "f"], "\n"),
         ]
 
         model = tatsu.compile(grammar, "document")

--- a/test/grammar/join_test.py
+++ b/test/grammar/join_test.py
@@ -57,13 +57,13 @@ class JoinTests(unittest.TestCase):
         codegen(model)
 
         ast = model.parse("x y, x y z", nameguard=False)
-        self.assertEqual([[['x', 'y'], ',', ['x', 'y']], 'z'], ast)
+        self.assertEqual(([['x', 'y'], ',', ['x', 'y']], 'z'), ast)
 
         ast = model.parse("x y z", nameguard=False)
-        self.assertEqual([[['x', 'y']], 'z'], ast)
+        self.assertEqual(([['x', 'y']], 'z'), ast)
 
         ast = model.parse("z", nameguard=False)
-        self.assertEqual([[], 'z'], ast)
+        self.assertEqual(([], 'z'), ast)
 
     def test_group_join(self):
         grammar = '''
@@ -123,13 +123,13 @@ class JoinTests(unittest.TestCase):
         codegen(model)
 
         ast = model.parse("x y, x y z", nameguard=False)
-        self.assertEqual([[['x', 'y'], ['x', 'y']], 'z'], ast)
+        self.assertEqual(([['x', 'y'], ['x', 'y']], 'z'), ast)
 
         ast = model.parse("x y z", nameguard=False)
-        self.assertEqual([[['x', 'y']], 'z'], ast)
+        self.assertEqual(([['x', 'y']], 'z'), ast)
 
         ast = model.parse("z", nameguard=False)
-        self.assertEqual([[], 'z'], ast)
+        self.assertEqual(([], 'z'), ast)
 
     def test_group_gather(self):
         grammar = '''

--- a/test/grammar/left_recursion_test.py
+++ b/test/grammar/left_recursion_test.py
@@ -40,16 +40,16 @@ class LeftRecursionTests(unittest.TestCase):
         model = compile(grammar, "test")
 
         ast = model.parse("1*2+3*5", trace=trace, colorize=True)
-        self.assertEqual([[['1', '*', '2'], '+', '3'], '*', '5'], ast)
+        self.assertEqual(((('1', '*', '2'), '+', '3'), '*', '5'), ast)
 
         ast = model.parse('10 - 20', trace=trace, colorize=True)
-        self.assertEqual(['10', '-', '20'], ast)
+        self.assertEqual(('10', '-', '20'), ast)
 
         ast = model.parse('( 10 - 20 )', trace=trace, colorize=True)
-        self.assertEqual(['10', '-', '20'], ast)
+        self.assertEqual(('10', '-', '20'), ast)
 
         ast = model.parse('3 + 5 * ( 10 - 20 )', trace=trace, colorize=True)
-        self.assertEqual([['3', '+', '5'], '*', ['10', '-', '20']], ast)
+        self.assertEqual((('3', '+', '5'), '*', ('10', '-', '20')), ast)
 
     def test_calc(self, trace=False):
         grammar = r'''
@@ -92,13 +92,13 @@ class LeftRecursionTests(unittest.TestCase):
         model = compile(grammar)
 
         ast = model.parse('10 - 20', trace=trace, colorize=True)
-        self.assertEqual(['10', '-', '20'], ast)
+        self.assertEqual(('10', '-', '20'), ast)
 
         ast = model.parse('( 10 - 20 )', trace=trace, colorize=True)
-        self.assertEqual(['10', '-', '20'], ast)
+        self.assertEqual(('10', '-', '20'), ast)
 
         ast = model.parse('3 + 5 * ( 10 - 20)', trace=trace, colorize=True)
-        self.assertEqual(['3', '+', ['5', '*', ['10', '-', '20']]], ast)
+        self.assertEqual(('3', '+', ('5', '*', ('10', '-', '20'))), ast)
 
     def test_calc_indirect(self, trace=False):
         grammar = r'''
@@ -118,10 +118,10 @@ class LeftRecursionTests(unittest.TestCase):
         '''
         model = compile(grammar)
         ast = model.parse('1-1+1', trace=trace, colorize=True)
-        self.assertEqual([['1', '-', '1'], '+', '1'], ast)
+        self.assertEqual((('1', '-', '1'), '+', '1'), ast)
 
         ast = model.parse('1+1-1', trace=trace, colorize=True)
-        self.assertEqual([['1', '+', '1'], '-', '1'], ast)
+        self.assertEqual((('1', '+', '1'), '-', '1'), ast)
 
         # from tatsu.tool import to_python_sourcecode
         # src = to_python_sourcecode(grammar)
@@ -140,7 +140,7 @@ class LeftRecursionTests(unittest.TestCase):
         '''
         model = compile(grammar, "test")
         ast = model.parse("5-87-32", trace=trace, colorize=True)
-        self.assertEqual([['5', '-', '87'], '-', '32'], ast)
+        self.assertEqual((('5', '-', '87'), '-', '32'), ast)
 
     def test_indirect_left_recursion_with_cut(self, trace=False):
         grammar = '''
@@ -153,7 +153,7 @@ class LeftRecursionTests(unittest.TestCase):
         model = compile(grammar, "test")
         ast = model.parse("5-87-32", trace=trace, colorize=True)
         print(ast)
-        self.assertEqual([['5', '-', '87'], '-', '32'], ast)
+        self.assertEqual((('5', '-', '87'), '-', '32'), ast)
 
     def test_indirect_left_recursion_complex(self, trace=False):
         grammar = '''
@@ -233,13 +233,13 @@ class LeftRecursionTests(unittest.TestCase):
         ast = model.parse("this", trace=trace, colorize=True)
         self.assertEqual('this', ast)
         ast = model.parse("this.x", trace=trace, colorize=True)
-        self.assertEqual(['this', '.', 'x'], ast)
+        self.assertEqual(('this', '.', 'x'), ast)
         ast = model.parse("this.x.y", trace=trace, colorize=True)
-        self.assertEqual([['this', '.', 'x'], '.', 'y'], ast)
+        self.assertEqual((('this', '.', 'x'), '.', 'y'), ast)
         ast = model.parse("this.x.m()", trace=trace, colorize=True)
-        self.assertEqual([['this', '.', 'x'], '.', 'm', '()'], ast)
+        self.assertEqual((('this', '.', 'x'), '.', 'm', '()'), ast)
         ast = model.parse("x[i][j].y", trace=trace, colorize=True)
-        self.assertEqual([[['x', '[', 'i', ']'], '[', 'j', ']'], '.', 'y'], ast)
+        self.assertEqual(((('x', '[', 'i', ']'), '[', 'j', ']'), '.', 'y'), ast)
 
     def test_no_left_recursion(self, trace=False):
         grammar = '''
@@ -290,13 +290,13 @@ class LeftRecursionTests(unittest.TestCase):
         model_a = compile(grammar_a, "test")
         model_b = compile(grammar_b, "test")
         ast = model_a.parse("1*2+3*4", trace=trace, colorize=True)
-        self.assertEqual([['1', '*', '2'], '+', ['3', '*', '4']], ast)
+        self.assertEqual((('1', '*', '2'), '+', ('3', '*', '4')), ast)
         ast = model_b.parse("(1+2)+(3+4)", trace=trace, colorize=True)
-        self.assertEqual([['1', '+', '2'], '+', ['3', '+', '4']], ast)
+        self.assertEqual((('1', '+', '2'), '+', ('3', '+', '4')), ast)
         ast = model_a.parse("1*2*3", trace=trace, colorize=True)
-        self.assertEqual([['1', '*', '2'], '*', '3'], ast)
+        self.assertEqual((('1', '*', '2'), '*', '3'), ast)
         ast = model_b.parse("(((1+2)))", trace=trace, colorize=True)
-        self.assertEqual(['1', '+', '2'], ast)
+        self.assertEqual(('1', '+', '2'), ast)
 
     @unittest.skip("For this the seed growing during left recursion is too primitive")
     def test_interlocking_cycles(self, trace=False):
@@ -376,7 +376,7 @@ class LeftRecursionTests(unittest.TestCase):
         '''
         model = compile(grammar, "test")
         ast = model.parse("1+2+3", trace=trace, colorize=True)
-        self.assertEqual(['1', '+', ['2', '+', '3']], ast)
+        self.assertEqual(('1', '+', ('2', '+', '3')), ast)
 
     def test_partial_input_bug(self, trace=False):
         grammar = r'''
@@ -404,7 +404,7 @@ class LeftRecursionTests(unittest.TestCase):
 
         model = compile(grammar)
         ast = model.parse(input, trace=trace, colorize=True)
-        assert ['{', 'size', '}'] == ast
+        assert ('{', 'size', '}') == ast
 
     def test_dropped_input_bug(self, trace=False):
         grammar = r'''
@@ -432,7 +432,7 @@ class LeftRecursionTests(unittest.TestCase):
         self.assertEqual('foo', ast)
 
         ast = model.parse('foo, bar', trace=trace, colorize=True)
-        self.assertEqual(['foo', ',', 'bar'], ast)
+        self.assertEqual(('foo', ',', 'bar'), ast)
 
     def test_change_start_rule(self, trace=False):
         grammar = r'''
@@ -456,7 +456,7 @@ class LeftRecursionTests(unittest.TestCase):
         model = compile(grammar)
 
         ast = model.parse('a * b', start='expr', trace=trace, colorize=True)
-        self.assertEqual(['a', '*', 'b'], ast)
+        self.assertEqual(('a', '*', 'b'), ast)
 
         try:
             model.parse('a * b', start='mul', trace=trace, colorize=True)
@@ -475,7 +475,7 @@ class LeftRecursionTests(unittest.TestCase):
         model = compile(grammar)
 
         ast = model.parse('a(b, c)', start='expr', trace=trace, colorize=True)
-        self.assertEqual(['a', '(', ['b', 'c'], ')'], ast)
+        self.assertEqual(('a', '(', ['b', 'c'], ')'), ast)
 
     def test_not_at_top_level(self):
         grammar = r"""
@@ -501,7 +501,7 @@ class LeftRecursionTests(unittest.TestCase):
             A = | A 'a' | 'a' ;
         '''
 
-        assert [['a', 'a'], 'a'] == parse(left_grammar, 'aaa')
+        assert (('a', 'a'), 'a') == parse(left_grammar, 'aaa')
 
         right_grammar = '''
             @@left_recursion :: True
@@ -511,7 +511,7 @@ class LeftRecursionTests(unittest.TestCase):
             A = | 'a' A | 'a' ;
         '''
 
-        assert ['a', ['a', 'a']] == parse(right_grammar, 'aaa')
+        assert ('a', ('a', 'a')) == parse(right_grammar, 'aaa')
 
     @unittest.skip('PEG associativity not implemented')
     def test_peg_associativity(self):
@@ -544,7 +544,7 @@ class LeftRecursionTests(unittest.TestCase):
             A = | A 'a' | () ;
         '''
 
-        assert [['a', 'a'], 'a'] == parse(left_grammar, 'aaa')
+        assert (('a', 'a'), 'a') == parse(left_grammar, 'aaa')
 
     def test_leftrec_with_void(self):
         left_grammar = '''
@@ -555,5 +555,5 @@ class LeftRecursionTests(unittest.TestCase):
             A = | A 'a' | 'a' ;
         '''
 
-        assert [['a', 'a'], 'a'] == parse(left_grammar, 'aaa')
+        assert (('a', 'a'), 'a') == parse(left_grammar, 'aaa')
         assert parse(left_grammar, '') is None

--- a/test/grammar/lookahead_test.py
+++ b/test/grammar/lookahead_test.py
@@ -19,7 +19,7 @@ class LookaheadTests(unittest.TestCase):
         '''
         m = compile(grammar, trace=trace)
         ast = m.parse('x xx yyy a b')
-        self.assertEqual(['x', ['a', 'b']], ast)
+        self.assertEqual(('x', ('a', 'b')), ast)
 
         grammar = '''
             start = 'x' ab $ ;
@@ -32,4 +32,4 @@ class LookaheadTests(unittest.TestCase):
         '''
         m = compile(grammar, trace=trace)
         ast = m.parse('x xx yyy a b')
-        self.assertEqual(['x', ['a', 'b']], ast)
+        self.assertEqual(('x', ('a', 'b')), ast)

--- a/test/grammar/pattern_test.py
+++ b/test/grammar/pattern_test.py
@@ -31,8 +31,8 @@ class PatternTests(unittest.TestCase):
         '''
 
         model = compile(grammar, "test")
-        ast = model.parse('\n\n', trace=True)
-        self.assertEqual(['\n', '\n'], ast)
+        ast = model.parse('\n\n')
+        self.assertEqual(('\n', '\n'), ast)
 
     def test_pattern_concatenation(self):
         grammar = '''

--- a/test/grammar/syntax_test.py
+++ b/test/grammar/syntax_test.py
@@ -106,7 +106,7 @@ class SyntaxTests(unittest.TestCase):
         '''
         model = compile(grammar, "test")
         ast = model.parse("1234", nameguard=False)
-        self.assertEqual(['1', '2', '3', '4'], ast)
+        self.assertEqual(('1', '2', '3', '4'), ast)
 
         grammar = '''
             start = '1' foo:['2' '3'] '4' $ ;
@@ -121,7 +121,7 @@ class SyntaxTests(unittest.TestCase):
         '''
         model = compile(grammar, "test")
         ast = model.parse("1234", nameguard=False)
-        self.assertEqual(['1', '2', '3', '4'], ast)
+        self.assertEqual(('1', '2', '3', '4'), ast)
 
     def test_partial_options(self):
         grammar = '''
@@ -142,7 +142,7 @@ class SyntaxTests(unittest.TestCase):
         '''
         model = compile(grammar, "test")
         ast = model.parse("AB", nameguard=False)
-        self.assertEqual(['A', 'B'], ast)
+        self.assertEqual(('A', 'B'), ast)
 
     def test_partial_choice(self):
         grammar = '''
@@ -219,7 +219,7 @@ class SyntaxTests(unittest.TestCase):
             '''
         model = compile(grammar, "test")
         ast = model.parse("abb", nameguard=False)
-        self.assertEqual(['a', 'b', 'b'], ast)
+        self.assertEqual(('a', 'b', 'b'), ast)
         self.assertEqual(trim(grammar), str(model))
 
     def test_rule_include(self):
@@ -231,7 +231,7 @@ class SyntaxTests(unittest.TestCase):
         '''
         model = compile(grammar, "test")
         ast = model.parse("abb", nameguard=False)
-        self.assertEqual(['a', 'b', 'b'], ast)
+        self.assertEqual(('a', 'b', 'b'), ast)
 
     def test_48_rule_override(self):
         grammar = '''
@@ -244,7 +244,7 @@ class SyntaxTests(unittest.TestCase):
         '''
         model = compile(grammar, "test")
         ast = model.parse("abb", nameguard=False)
-        self.assertEqual(['a', 'b', 'b'], ast)
+        self.assertEqual(('a', 'b', 'b'), ast)
 
     def test_failed_ref(self):
         grammar = r"""
@@ -285,7 +285,7 @@ class SyntaxTests(unittest.TestCase):
         model = compile(grammar, "test")
         codegen(model)
         ast = model.parse("xxxy", nameguard=False)
-        self.assertEqual([['x', 'x', 'x'], [], 'y'], ast)
+        self.assertEqual((['x', 'x', 'x'], [], 'y'), ast)
 
     def test_parseinfo(self):
         grammar = '''
@@ -318,7 +318,7 @@ class SyntaxTests(unittest.TestCase):
         '''
         model = compile(grammar, "start")
         ast = model.parse("1xx 2 yy")
-        self.assertEqual(['1', 'xx', ' ', '2', 'yy'], ast)
+        self.assertEqual(('1', 'xx', ' ', '2', 'yy'), ast)
 
     def test_constant(self):
         grammar = '''


### PR DESCRIPTION
The result of parsing a sequence was the same as parsing a closure: list/closure(list).

This change makes the result of sequences be `tuple`:
* a minor change in the ast-generating code
* an important backwards incompatibility
* a huge improvement in AST semantics
* an important improvement in runtime efficiency