### PR TITLE
[grammar][parser] add 'alert' expressions to grammar

### DIFF
--- a/docs/syntax.rst
+++ b/docs/syntax.rst
@@ -356,12 +356,27 @@ The expressions, in reverse order of operator precedence, can be:
 
 .. code:: python
 
-            eval(f'{repr(constant)}.format(**{ast})')
+    eval(f'{repr(constant)}.format(**{ast})')
 
 `````constant`````
 ^^^^^^^^^^^^^^^^^^
 
     A multiline version of ```constant```.
+
+
+^```constant``` and ^`````constant`````
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    An alert. There will be no token returned by the parser, but an alert will be registed in the parse context and added to the current node's ``parseinfo``.
+
+    The ``^`` character may appear more than once to indicate the alert level.
+
+
+.. code::
+
+    assignment = identifier '=' (
+        | value
+        | ->'&; ^^^`could not parse value in assignment to {identifier}`
 
 
 ``rulename``

--- a/grammar/tatsu.ebnf
+++ b/grammar/tatsu.ebnf
@@ -348,7 +348,7 @@ skip_to::SkipTo
 
 atom
     =
-    cut | cut_deprecated | token | constant | call | pattern | eof
+    cut | cut_deprecated | token | alert | constant | call | pattern | eof
     ;
 
 
@@ -397,6 +397,12 @@ constant::Constant
         | "`" @:literal "`"
         | /`(.*?)`/
     )
+    ;
+
+
+alert::Alert
+    =
+     level:/\^+/ message:constant
     ;
 
 

--- a/tatsu/bootstrap.py
+++ b/tatsu/bootstrap.py
@@ -685,11 +685,12 @@ class EBNFBootstrapParser(Parser):
             self._error(
                 'expecting one of: '
                 "'!' '&' '(' '()' '->' '?(' '[' '{'"
-                '<atom> <call> <closure> <constant> <cut>'
-                '<cut_deprecated> <empty_closure> <eof>'
-                '<gather> <group> <join> <left_join>'
-                '<lookahead> <negative_lookahead>'
-                '<optional> <pattern> <positive_closure>'
+                '<alert> <atom> <call> <closure>'
+                '<constant> <cut> <cut_deprecated>'
+                '<empty_closure> <eof> <gather> <group>'
+                '<join> <left_join> <lookahead>'
+                '<negative_lookahead> <optional>'
+                '<pattern> <positive_closure>'
                 '<right_join> <separator> <skip_to>'
                 '<special> <token> <void>'
             )
@@ -981,6 +982,8 @@ class EBNFBootstrapParser(Parser):
             with self._option():
                 self._token_()
             with self._option():
+                self._alert_()
+            with self._option():
                 self._constant_()
             with self._option():
                 self._call_()
@@ -990,10 +993,10 @@ class EBNFBootstrapParser(Parser):
                 self._eof_()
             self._error(
                 'expecting one of: '
-                "'$' '>>' '`' '~' <call> <constant> <cut>"
-                '<cut_deprecated> <eof> <pattern>'
-                '<raw_string> <regexes> <string> <token>'
-                '<word>'
+                "'$' '>>' '`' '~' <alert> <call>"
+                '<constant> <cut> <cut_deprecated> <eof>'
+                '<pattern> <raw_string> <regexes>'
+                '<string> <token> <word> \\^+'
             )
 
     @tatsumasu('RuleRef')
@@ -1046,6 +1049,17 @@ class EBNFBootstrapParser(Parser):
                     'expecting one of: '
                     "'`' '```' `(.*?)`"
                 )
+
+    @tatsumasu('Alert')
+    def _alert_(self):  # noqa
+        self._pattern('\\^+')
+        self.name_last_node('level')
+        self._constant_()
+        self.name_last_node('message')
+        self._define(
+            ['level', 'message'],
+            []
+        )
 
     @tatsumasu('Token')
     def _token_(self):  # noqa
@@ -1355,6 +1369,9 @@ class EBNFBootstrapSemantics:
         return ast
 
     def constant(self, ast):  # noqa
+        return ast
+
+    def alert(self, ast):  # noqa
         return ast
 
     def token(self, ast):  # noqa

--- a/tatsu/codegen/python.py
+++ b/tatsu/codegen/python.py
@@ -117,9 +117,19 @@ class Token(Base):
 
 class Constant(Base):
     def render_fields(self, fields):
-        fields.update(literal=repr(self.node.literal))
+        fields.update(constant=repr(self.node.literal))
 
-    template = "self._constant({literal})"
+    template = "self._constant({constant})"
+
+
+class Alert(Base):
+    def render_fields(self, fields):
+        fields.update(
+            literal=repr(self.node.literal),
+            level=self.node.level,
+        )
+
+    template = "self._alert({literal}, {level})"
 
 
 class Pattern(Base):

--- a/tatsu/contexts.py
+++ b/tatsu/contexts.py
@@ -730,6 +730,11 @@ class ParseContext:
         self._append_cst(literal)
         return literal
 
+    def _alert(self, literal, level):
+        self._next_token()
+        self._trace_match(f'{"^" * level}`{literal}`')
+        return None
+
     def _pattern(self, pattern):
         token = self.tokenizer.matchre(pattern)
         if token is None:

--- a/tatsu/contexts.py
+++ b/tatsu/contexts.py
@@ -21,6 +21,7 @@ from .util import prune_dict, is_list, info, safe_name
 from .util import left_assoc, right_assoc
 from .tokenizing import Tokenizer
 from .infos import (
+    Alert,
     MemoKey,
     ParseInfo,
     RuleInfo,
@@ -549,12 +550,13 @@ class ParseContext:
     def _get_parseinfo(self, name, pos):
         endpos = self._pos
         return ParseInfo(
-            self.tokenizer,
-            name,
-            pos,
-            endpos,
-            self.tokenizer.posline(pos),
-            self.tokenizer.posline(endpos),
+            tokenizer=self.tokenizer,
+            rule=name,
+            pos=pos,
+            endpos=endpos,
+            line=self.tokenizer.posline(pos),
+            endline=self.tokenizer.posline(endpos),
+            alerts=self.state.alerts,
         )
 
     @property
@@ -730,9 +732,10 @@ class ParseContext:
         self._append_cst(literal)
         return literal
 
-    def _alert(self, literal, level):
+    def _alert(self, message, level):
         self._next_token()
-        self._trace_match(f'{"^" * level}`{literal}`')
+        self._trace_match(f'{"^" * level}`{message}`', failed=True)
+        self.state.alerts.append(Alert(message=message, level=level))
         return None
 
     def _pattern(self, pattern):

--- a/tatsu/grammars.py
+++ b/tatsu/grammars.py
@@ -342,7 +342,7 @@ class Constant(Model):
             text = self.literal
             if '\n' in text:
                 text = trim(text)
-            return eval(f'{repr(text)}.format(**{ctx.ast})')  # pylint: disable=eval-used
+            return eval(f'{"f" + repr(text)}', {}, dict(ctx.ast))  # pylint: disable=eval-used
         else:
             return self.literal
 
@@ -350,10 +350,24 @@ class Constant(Model):
         return {()}
 
     def _to_str(self, lean=False):
-        return '`%s`' % repr(self.literal)
+        return f'`{repr(self.literal)}`'
 
     def _nullable(self):
         return True
+
+
+class Alert(Constant):
+    def __post_init__(self):
+        super().__post_init__()
+        self.literal = self.ast.message.literal
+        self.level = len(self.ast.level)
+
+    def parse(self, ctx):
+        message = super().parse(ctx)
+        return message
+
+    def _to_str(self, lean=False):
+        return f'{"^" * self.level}{super()._to_str()}'
 
 
 class Pattern(Model):

--- a/tatsu/infos.py
+++ b/tatsu/infos.py
@@ -168,6 +168,11 @@ class CommentInfo(NamedTuple):
         return CommentInfo([], [])
 
 
+class Alert(NamedTuple):
+    level: int = 1
+    message: str = ''
+
+
 class ParseInfo(NamedTuple):
     tokenizer: Any
     rule: str
@@ -175,6 +180,7 @@ class ParseInfo(NamedTuple):
     endpos: int
     line: int
     endline: int
+    alerts: list[Alert] = []
 
     def text_lines(self):
         return self.tokenizer.get_lines(self.line, self.endline)
@@ -225,3 +231,4 @@ class ParseState:
     pos: int = 0
     ast: AST = dataclasses.field(default_factory=AST)
     cst: Any = None
+    alerts: list[Alert] = dataclasses.field(default_factory=list)

--- a/test/grammar/alerts_test.py
+++ b/test/grammar/alerts_test.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from tatsu.tool import parse
+
+
+def test_alert_interpolation():
+    input = '42 69'
+    grammar = '''
+            start = a:number b: number i:^`"seen: {a}, {b}"` $ ;
+            number = /\d+/ ;
+    '''
+    assert parse(grammar, input) == {'a': '42', 'b': '69', 'i': 'seen: 42, 69'}


### PR DESCRIPTION
^``constant``

An alert. There will be no token returned by the parser, but an alert will be registed in the parse context and added to the current node's `parseinfo`.

The `^` character may appear more than once to indicate the alert level.

```
    assignment = identifier '=' (
        | value
        | ->'&; ^^^`could not parse value in assignment to {identifier}`
```