### PR TITLE
[contexts] revert cut expressions applying only to local rule

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,6 @@ The format of this *Change Log* is inspired by `keeapachangelog.org`_.
 * Patch problem with pickling ``FailedCut`` while running parsing in parallel.
 * Optimize model pickling and parallel processing to reduce runtime and memory use with ``parproc``
 * Add a representation of ``~`` cut expressions to parse traces
-* The effects of the ``~`` cut expression are now local to the rule in which they are present. Allowing cuts to escape a rule is sometimes useful, but may lead to grammar bugs that are difficult to resolve (`@gvanrossum`_)
 
 
 `5.7.3`_ @ 2021-12-20

--- a/docs/syntax.rst
+++ b/docs/syntax.rst
@@ -104,10 +104,9 @@ The expressions, in reverse order of operator precedence, can be:
 
 ``~``
 ^^^^^
-    The *cut* expression. Commit to the current option and prevent other options from being considered even if what follows fails to parse.
+    The *cut* expression. Commit to the current active option and prevent other options from being considered even if what follows fails to parse.
 
-    In this example, other options won't be considered if a
-    parenthesis is parsed:
+    In this example, other options won't be considered if a parenthesis is parsed:
 
 .. code::
 
@@ -129,8 +128,6 @@ There are options also in closures, because of a similar equivalency, so the fol
             =
             ','.{name '=' ~ expression}
             ;
-
-The ``~`` expression applies only withn the rule in which it's present. It's effects will not escape to to the context of invoking rules.
 
 
 ``s%{ e }+``

--- a/tatsu/contexts.py
+++ b/tatsu/contexts.py
@@ -604,7 +604,6 @@ class ParseContext:
 
     def _call(self, ruleinfo):
         self._rule_stack += [ruleinfo]
-        self._cut_stack += [False]
         pos = self._pos
         try:
             self._trace_entry()
@@ -629,7 +628,6 @@ class ParseContext:
             self._trace_failure(e)
             raise
         finally:
-            self._cut_stack.pop()
             self._rule_stack.pop()
 
     def _clear_recursion_errors(self):


### PR DESCRIPTION
The easy optimizations available under the traditional semantics would be lost if cut doesn't escape a rule.

The grammar would have to add lookaheads to each option in a choice to achieve the same, while previously adding a cut after a keyword was enough.