### PR TITLE
Silence a couple of pylint warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -165,7 +165,7 @@ disable=
     # c-extension-no-member,  # I1101
     # literal-comparison,  # R0123
     # comparison-with-itself,  # R0124
-    no-self-use,  # R0201
+    # no-self-use,  # R0201
     # no-classmethod-decorator,  # R0202
     # no-staticmethod-decorator,  # R0203
     # useless-object-inheritance,  # R0205

--- a/tatsu/ast.py
+++ b/tatsu/ast.py
@@ -28,9 +28,6 @@ class AST(dict):
     def set_parseinfo(self, value):
         super().__setitem__('parseinfo', value)
 
-    def copy(self):
-        return self.__copy__()
-
     def asjson(self):
         return asjson(self)
 
@@ -54,6 +51,8 @@ class AST(dict):
 
     def __copy__(self):
         return AST(self)
+
+    copy = __copy__
 
     def __getitem__(self, key):
         if key in self:


### PR DESCRIPTION
The warnings showed up in the CI run for another pull request. Probably new warnings due to the pylint version not being pinned.