### PR TITLE
[model] Fall back to repr() for objects not handled by json module

### DIFF
--- a/tatsu/util/_common.py
+++ b/tatsu/util/_common.py
@@ -293,8 +293,14 @@ def plainjson(obj):
         return obj
 
 
+class FallbackJSONEncoder(json.JSONEncoder):
+    """A JSON Encoder that falls back to repr() for non-JSON-aware objects."""
+    def default(self, obj):
+        return repr(obj)
+
+
 def asjsons(obj):
-    return json.dumps(asjson(obj), indent=2)
+    return json.dumps(asjson(obj), indent=2, cls=FallbackJSONEncoder)
 
 
 def prune_dict(d, predicate):


### PR DESCRIPTION
The __str__() method of Node returns a JSON representation of the
Node. This fails if the Node contains anything that cannot be
represented by plain JSON. Notable examples are datetime and date
objects that are not so unrealistic for a parser to return.

Use a custom JSON encoder that fall back to repr() for these objects
so that a string representation for a Node can always be returned.

Fixes #262.