### PR TITLE
[treewide] Remove 'from __future__ import generator_stop'

### DIFF
--- a/examples/calc/calc.py
+++ b/examples/calc/calc.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import json
 from pprint import pprint
 

--- a/examples/calc/codegen.py
+++ b/examples/calc/codegen.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import sys
 
 from tatsu.codegen import ModelRenderer

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-from __future__ import generator_stop

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 
 def main():
     import pytest

--- a/test/ast_test.py
+++ b/test/ast_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 
 from tatsu.ast import AST

--- a/test/buffering_test.py
+++ b/test/buffering_test.py
@@ -3,8 +3,6 @@
 Tests for consistency of the line information caches kept by
 tatsu.buffering.Buffer.
 """
-from __future__ import generator_stop
-
 import os
 import random
 import unittest

--- a/test/codegen_test.py
+++ b/test/codegen_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 
 from tatsu.codegen import CodeGenerator, ModelRenderer

--- a/test/diagram_test.py
+++ b/test/diagram_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import sys
 import unittest
 import pytest

--- a/test/grammar/directive_test.py
+++ b/test/grammar/directive_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 
 import tatsu

--- a/test/grammar/firstfollow_test.py
+++ b/test/grammar/firstfollow_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 
 from tatsu.tool import compile

--- a/test/grammar/join_test.py
+++ b/test/grammar/join_test.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 import unittest
 from ast import parse
 

--- a/test/grammar/keyword_test.py
+++ b/test/grammar/keyword_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 from ast import parse
 

--- a/test/grammar/left_recursion_test.py
+++ b/test/grammar/left_recursion_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 
 from tatsu.exceptions import FailedParse

--- a/test/grammar/lookahead_test.py
+++ b/test/grammar/lookahead_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 
 from tatsu.tool import compile

--- a/test/grammar/parameter_test.py
+++ b/test/grammar/parameter_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 
 from tatsu.parser import GrammarGenerator

--- a/test/grammar/pattern_test.py
+++ b/test/grammar/pattern_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 
 from tatsu.util import trim

--- a/test/grammar/pretty_test.py
+++ b/test/grammar/pretty_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 
 from tatsu.util import trim

--- a/test/grammar/semantics_test.py
+++ b/test/grammar/semantics_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 from typing import Any
 

--- a/test/grammar/stateful_test.py
+++ b/test/grammar/stateful_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 
 from tatsu.exceptions import FailedSemantics

--- a/test/grammar/syntax_test.py
+++ b/test/grammar/syntax_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 
 from tatsu.exceptions import FailedParse

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 from tatsu.objectmodel import Node
 
 

--- a/test/parsing_test.py
+++ b/test/parsing_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import generator_stop
-
 import unittest
 import tempfile
 

--- a/test/walker_test.py
+++ b/test/walker_test.py
@@ -1,5 +1,3 @@
-from __future__ import generator_stop
-
 import json
 from collections import defaultdict
 


### PR DESCRIPTION
PEP 479, StopIteration handling inside generators, enabled by 'from
__future__ import generator_stop' is the default since Python 3.7 and
thus for all supported Python releases.

https://docs.python.org/3.10/library/__future__.html