### PR TITLE
Fixes for initial grammar rule handling

### DIFF
--- a/docs/use.rst
+++ b/docs/use.rst
@@ -245,7 +245,7 @@ passing the grammar to parse and the starting rule's name as parameter:
     from myparser import MyParser
 
     parser = MyParser()
-    ast = parser.parse('text to parse', rule_name='start')
+    ast = parser.parse('text to parse', start='start')
     print(ast)
     print(json.dumps(asjson(ast), indent=2))
 
@@ -258,7 +258,7 @@ method:
 
 .. code:: python
 
-    model = parser.parse(text, rule_name='start', semantics=MySemantics())
+    model = parser.parse(text, start='start', semantics=MySemantics())
 
 If special lexical treatment is required (as in *80 column* languages),
 then a descendant of ``tatsu.tokenizing.Tokenizer`` can be passed instead of
@@ -270,7 +270,7 @@ the text:
         ...
 
     tokenizer = MySpecialTokenizer(text)
-    model = parser.parse(tokenizer, rule_name='start', semantics=MySemantics())
+    model = parser.parse(tokenizer, start='start', semantics=MySemantics())
 
 The generated parser's module can also be invoked as a script:
 

--- a/tatsu/bootstrap.py
+++ b/tatsu/bootstrap.py
@@ -1434,7 +1434,7 @@ def main(filename, start=None, **kwargs):
     parser = EBNFBootstrapParser()
     return parser.parse(
         text,
-        rule_name=start,
+        start=start,
         filename=filename,
         **kwargs
     )

--- a/tatsu/codegen/python.py
+++ b/tatsu/codegen/python.py
@@ -562,6 +562,7 @@ class Grammar(Base):
                             namechars={namechars},
                             parseinfo={parseinfo},
                             keywords=KEYWORDS,
+                            start={start!r},
                         )
                         config = config.replace(**settings)
                         super().__init__(config=config)
@@ -573,9 +574,7 @@ class Grammar(Base):
                 {abstract_rules}
 
 
-                def main(filename, start=None, **kwargs):
-                    if start is None:
-                        start = '{start}'
+                def main(filename, **kwargs):
                     if not filename or filename == '-':
                         text = sys.stdin.read()
                     else:
@@ -584,7 +583,6 @@ class Grammar(Base):
                     parser = {name}Parser()
                     return parser.parse(
                         text,
-                        rule_name=start,
                         filename=filename,
                         **kwargs
                     )

--- a/tatsu/grammars.py
+++ b/tatsu/grammars.py
@@ -1084,7 +1084,7 @@ class Grammar(Model):
         start = config.effective_rule_name()
         if start is None:
             start = self.rules[0].name
-            config.start_rule = start
+            config.start_rule = start # FIXME
 
         if ctx is None:
             ctx = ModelContext(self.rules, config=config)

--- a/tatsu/infos.py
+++ b/tatsu/infos.py
@@ -28,6 +28,7 @@ class ParserConfig:
 
     start: str|None = None  # FIXME
     start_rule: str|None = None  # FIXME
+    rule_name: str|None = None # Backward compatibility
 
     comments_re: str|None = COMMENTS_RE
     eol_comments_re: str|None = EOL_COMMENTS_RE
@@ -78,6 +79,7 @@ class ParserConfig:
         # note: there are legacy reasons for this mess
         return (
             self.start_rule or
+            self.rule_name or
             self.start
         )
 

--- a/test/parser_equivalence_test.py
+++ b/test/parser_equivalence_test.py
@@ -124,3 +124,18 @@ def test_name_checked():
     subtest(parser)
     parser = generate_and_load_parser('test_name_checked', grammar)
     subtest(parser)
+
+
+def test_first_rule():
+    grammar = '''
+        @@grammar :: Test
+
+        true = 'test' @: `True` $ ;
+        start = 'test' @: `False` $ ;
+    '''
+    parser = compile(grammar, 'Test')
+    ast = parser.parse('test')
+    assert ast == True
+    parser = generate_and_load_parser('test_first_rule', grammar)
+    ast = parser.parse('test')
+    assert ast == True

--- a/test/parsing_test.py
+++ b/test/parsing_test.py
@@ -59,22 +59,35 @@ class ParsingTests(unittest.TestCase):
         self.assertEqual('\nañez', eval_escapes(r'\na\xf1ez'))
         self.assertEqual('\nañez', eval_escapes(r'\nañez'))
 
-    def test_rule_name(self):
+    def test_start(self):
         grammar = '''
             @@grammar :: Test
 
-            start = test $;
-            test = "test";
+            true = "test" @:`True` $;
+            false = "test" @:`False` $;
+
         '''
         model = tatsu.compile(grammar=grammar)
         self.assertEqual('Test', model.directives.get('grammar'))
         self.assertEqual('Test', model.name)
 
+        # By default, parsing starts from the first rule in the grammar.
         ast = model.parse("test")
-        self.assertEqual(ast, "test")
+        self.assertEqual(ast, True)
 
-        ast = tatsu.parse(grammar, "test", rule_name='start')
-        self.assertEqual(ast, "test")
+        # The start rule can be passed explicitly.
+        ast = model.parse("test", start='true')
+        self.assertEqual(ast, True)
+        # Backward compatibility argument name.
+        ast = model.parse("test", rule_name='true')
+        self.assertEqual(ast, True)
+
+        # The default rule can be overwritten.
+        ast = tatsu.parse(grammar, "test", start='false')
+        self.assertEqual(ast, False)
+        # Backward compatibility argument name.
+        ast = tatsu.parse(grammar, "test", rule_name='false')
+        self.assertEqual(ast, False)
 
     def test_rule_capitalization(self):
         grammar = '''

--- a/test/parsing_test.py
+++ b/test/parsing_test.py
@@ -97,13 +97,13 @@ class ParsingTests(unittest.TestCase):
         test_string = 'test 12'
         lowercase_rule_names = ['nocaps', 'camelCase', 'tEST']
         uppercase_rule_names = ['Capitalized', 'CamelCase', 'TEST']
-        ref_lowercase_result = tatsu.parse(grammar.format(rulename='reflowercase'), test_string, rule_name='start')
-        ref_uppercase_result = tatsu.parse(grammar.format(rulename='Refuppercase'), test_string, rule_name='start')
+        ref_lowercase_result = tatsu.parse(grammar.format(rulename='reflowercase'), test_string)
+        ref_uppercase_result = tatsu.parse(grammar.format(rulename='Refuppercase'), test_string)
         for rulename in lowercase_rule_names:
-            result = tatsu.parse(grammar.format(rulename=rulename), test_string, rule_name='start')
+            result = tatsu.parse(grammar.format(rulename=rulename), test_string)
             self.assertEqual(result, ref_lowercase_result)
         for rulename in uppercase_rule_names:
-            result = tatsu.parse(grammar.format(rulename=rulename), test_string, rule_name='start')
+            result = tatsu.parse(grammar.format(rulename=rulename), test_string)
             self.assertEqual(result, ref_uppercase_result)
 
     def test_startrule_issue62(self):


### PR DESCRIPTION
There were some confusion around the `rule_name` / `start` argument to the `parse()` method. These patches hopefully fix that. I haven't understood what is the role of `start_rule` in the `ParserConfig` dataclass but I suspect it is there for backward compatibility with generated parsers, thus I didn't touch it.

This may require regenerating the bootstrapped EBNF parser.