### PR TITLE
[walkers] Make implementation of NodeWalker more regular

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ The format of this *Change Log* is inspired by `keeapachangelog.org`_.
 ---------------
 .. _`X.Y.Z`: https://github.com/apalala/tatsu/compare/v5.8.0...master
 
+* A non-empty ``__init__`` method has been added to the ``NodeWalker`` class definition. Subclasses that define an ``__init__`` method should be updated to make sure they call the parent class ``__init__`` method.
+
 `5.8.0`_ @ 2022-03-12
 ---------------------
 .. _`5.8.0`: https://github.com/apalala/tatsu/compare/v5.7.3...v5.8.0

--- a/tatsu/walkers.py
+++ b/tatsu/walkers.py
@@ -9,9 +9,8 @@ from tatsu.util import is_list
 
 
 class NodeWalker:
-    def __new__(cls, *args, **kwargs):
-        cls._walker_cache = {}
-        return super(NodeWalker, cls).__new__(cls)
+    def __init__(self):
+        self._walker_cache = {}
 
     def walk(self, node: Node|list[Node], *args, **kwargs) -> Any:
         if isinstance(node, list):

--- a/test/zzz_bootstrap/bootstrap_test.py
+++ b/test/zzz_bootstrap/bootstrap_test.py
@@ -155,6 +155,7 @@ class BootstrapTests(unittest.TestCase):
 
         class PrintNameWalker(DepthFirstWalker):
             def __init__(self):
+                super().__init__()
                 self.walked = []
 
             def walk_default(self, o, children):


### PR DESCRIPTION
NodeWalker defines a __new__() method that takes the unusual step of
modifying the class definition received as first argument adding a
_walker_cache class member. This means that all NodeWalker subclass
instances share the same _walker_cache and that this dictionary in
reset every time a new NodeWalker instance is created.

It may be that this implementation was an attempt to add instance
initialization without requiting subclasses to have to call
super().__init__() in their initialization. However, this results in
somehow bizarre behavior.

Changing the implementation to obtain a more regular and expected
behavior is worth the minuscule compatibility breakage of requiring
sublasses to call the parent __init__() method. Failing to do so
manifests with an obvious error and the fix is straightforward.

Fixes #266.