### PR TITLE
Add setuptools extension to compile TatSu grammar into Python code

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
 python_version = 3.9
 ignore_missing_imports = True
-exclude = parsers|docs|build|tmp
+exclude = parsers|docs|build|tmp|test/setuptools/

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,8 @@ tests_require = pytest-mypy
 console_scripts =
     tatsu = tatsu:main
     g2e = tatsu.g2e:main
+distutils.setup_keywords =
+    tatsu_parsers = tatsu.setuptools:parser
 
 [options.extras_require]
 future-regex = regex

--- a/tatsu/setuptools.py
+++ b/tatsu/setuptools.py
@@ -1,0 +1,67 @@
+"""Tatsu code generation integration into setuptools."""
+
+import os
+import logging
+
+from setuptools.errors import SetupError
+from setuptools.extension import Extension
+from setuptools.command.build_ext import _build_ext
+
+import tatsu.parser
+import tatsu.codegen.python
+
+
+class Parser(Extension):
+    pass
+
+
+def error(msg):
+    raise SetupError(msg)
+
+
+def parser(dist, attr, value):
+    assert attr == 'tatsu_parsers'
+
+    if dist.ext_modules is None:
+        dist.ext_modules = []
+
+    for spec in value:
+        if not isinstance(spec, str):
+            error('argument to tatsu_parsers= must be a list of strings')
+        try:
+            grammar, module = spec.split(':')
+        except ValueError:
+            error('arguments to tatsu_parser= must be in the form "path/to/grammar.ebnf:module.name"')
+        dist.ext_modules.append(Parser(module, [grammar]))
+
+    build_ext_base = dist.cmdclass.get('build_ext', _build_ext)
+
+    class build_ext(build_ext_base):
+        def run(self):
+            get_package_dir = self.get_finalized_command('build_py').get_package_dir
+            extensions = []
+            for ext in self.extensions:  # pylint: disable=access-member-before-definition
+                if not isinstance(ext, Parser):
+                    extensions.append(ext)
+                grammar = ext.sources[0]
+                path = ext.name.split('.')
+                package = '.'.join(path[:-1])
+                filename = os.path.join(get_package_dir(package), path[-1] + '.py')
+                if not self.inplace:
+                    filename = os.path.join(self.build_lib, filename)
+                logging.info('generating TatSu parser %s from grammar %s', filename, grammar)
+                generate_parser(grammar, filename)
+            self.extensions = extensions
+            super().run()
+
+    dist.cmdclass['build_ext'] = build_ext
+
+
+def generate_parser(grammar, filename):
+    with open(grammar, 'r', encoding='utf8') as fd:
+        src = fd.read()
+    model = tatsu.parser.GrammarGenerator().parse(src)
+    code = tatsu.codegen.python.codegen(model)
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    with open(filename, 'w', encoding='utf8') as fd:
+        fd.write(code)

--- a/test/setuptools/README
+++ b/test/setuptools/README
@@ -1,0 +1,1 @@
+Example of TatSu code generation integration into setuptools

--- a/test/setuptools/example/__init__.py
+++ b/test/setuptools/example/__init__.py
@@ -1,0 +1,5 @@
+from . import parser
+
+
+def parse(text):
+    return parser.CALCParser().parse(text)

--- a/test/setuptools/example/calc.ebnf
+++ b/test/setuptools/example/calc.ebnf
@@ -1,0 +1,36 @@
+@@grammar::CALC
+
+
+start
+    =
+    expression $
+    ;
+
+
+expression
+    =
+    | expression '+' term
+    | expression '-' term
+    | term
+    ;
+
+
+term
+    =
+    | term '*' factor
+    | term '/' factor
+    | factor
+    ;
+
+
+factor
+    =
+    | '(' expression ')'
+    | number
+    ;
+
+
+number
+    =
+    /\d+/
+    ;

--- a/test/setuptools/setup.py
+++ b/test/setuptools/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+setup(
+    name="example",
+    version="0.1",
+    author='TatSu',
+    author_email='tatsu@example.net',
+    url='https://github.com/neogeny/TatSu/tree/master/test/setuptools/',
+    packages=["example"],
+    setup_requires=["tatsu>=5.8.2"],
+    tatsu_parsers=[
+        "example/calc.ebnf:example.parser",
+    ],
+    install_requires=["tatsu>=5.8.2"],
+)


### PR DESCRIPTION
This is a proof of concept for an extension to setuptools that compiles a TatSu grammar into a python module at build time. I added an example of how it can be used to the `tests` folder, planning to turn it into an actual test. It boils down to specifying a new keyword argument to `setup()` into `setup.py` in the form:
```
    tatsu_parsers=[
        "example/calc.ebnf:example.parser",
    ],
```
where the argument value is a list of strings with the path of the grammar EBNF source and the destination  Python module name separated by a colon.

Documentation and tests are missing. I can add those if a tool like this is considered interesting.