### PR TITLE
pass multiplier argument

### DIFF
--- a/tatsu/rendering.py
+++ b/tatsu/rendering.py
@@ -100,7 +100,7 @@ class Renderer:
         return self._formatter.render(item, join=join, **fields)
 
     def indent(self, item, ind=1, multiplier=4):
-        return indent(self.rend(item), indent=ind)
+        return indent(self.rend(item), indent=ind, multiplier=multiplier)
 
     def trim(self, item, tabwidth=4):
         return trim(self.rend(item), tabwidth=tabwidth)


### PR DESCRIPTION
Is the current behavior intended? Currently, argument `multiplier` passed are simply ignored.