### PR TITLE
add missing annotation in tutorial, typo and whitespace cleanup

### DIFF
--- a/docs/directives.rst
+++ b/docs/directives.rst
@@ -71,7 +71,7 @@ Enables left-recursive rules in the grammar. See the `Left Recursion`_ sections 
 ``@@namechars :: <string>``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A list of (non-alfanumeric) characters that should be considered part of names when using the `@@nameguard`_ feature:
+A list of (non-alphanumeric) characters that should be considered part of names when using the `@@nameguard`_ feature:
 
 .. code::
 
@@ -83,7 +83,7 @@ A list of (non-alfanumeric) characters that should be considered part of names w
 ``@@nameguard :: <bool>``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When set to ``True``, avoids matching tokens when the next character in the input sequence is alfarnumeric or a ``@@namechar``. Defaults to ``True``. See the `'text' expression`_ for an explanation.
+When set to ``True``, avoids matching tokens when the next character in the input sequence is alphanumeric or a ``@@namechar``. Defaults to ``True``. See the `'text' expression`_ for an explanation.
 
 .. code::
 

--- a/docs/mini-tutorial.rst
+++ b/docs/mini-tutorial.rst
@@ -382,7 +382,7 @@ Having semantic actions determine what was parsed with ``isinstance()`` or query
 
     division
         =
-        left:term '/' ~ right:factor
+        left:term op:'/' ~ right:factor
         ;
 
 
@@ -511,7 +511,7 @@ The first step to create an object model is to annotate the rule names with the 
 
     division::Divide
         =
-        left:factor '/' ~ right:term
+        left:factor op:'/' ~ right:term
         ;
 
 

--- a/docs/syntax.rst
+++ b/docs/syntax.rst
@@ -771,16 +771,16 @@ the language. Those reserved tokens are known as `Reserved Words`_ or
 `Keywords`_
 
 |TatSu| provides support for preventing the use of `keywords`_ as
-identifiers though the ``@@ keyword`` directive,and the ``@ name``
+identifiers though the ``@@keyword`` directive,and the ``@name``
 decorator.
 
 A grammar may specify reserved tokens providing a list of them in one or
-more ``@@ keyword`` directives::
+more ``@@keyword`` directives::
 
   @@keyword :: if endif
   @@keyword :: else elseif
 
-The ``@ name`` decorator checks that the result of a grammar rule does
+The ``@name`` decorator checks that the result of a grammar rule does
 not match a token defined as a `keyword`_::
 
   @name


### PR DESCRIPTION
The mini tutorial, when introducing grammar annotation, failed to add annotate the division expression.

s/alfanumeric/alphanumeric/ along with s/alfarnumeric/alphanumeric/ in the directives documentation.

Remove whitespace between @ or @@ and the directive when discussing reserved word handling in the syntax documentation, consistent with how directives are formatted elsewhere.