### PR TITLE
Pre-compile regexps

### DIFF
--- a/tatsu/infos.py
+++ b/tatsu/infos.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import copy
 import dataclasses
 from collections.abc import Callable, Mapping
@@ -29,8 +30,8 @@ class ParserConfig:
     start_rule: str | None = None  # FIXME
     rule_name: str | None = None  # Backward compatibility
 
-    comments_re: str | None = None
-    eol_comments_re: str | None = None
+    comments_re: re.Pattern | None = None
+    eol_comments_re: re.Pattern | None = None
 
     tokenizercls: type[Tokenizer] | None = None  # FIXME
     semantics: type | None = None
@@ -63,9 +64,9 @@ class ParserConfig:
         if self.ignorecase:
             self.keywords = [k.upper() for k in self.keywords]
         if self.comments:
-            self.comments_re = self.comments
+            self.comments_re = re.compile(self.comments)
         if self.eol_comments:
-            self.eol_comments_re = self.eol_comments
+            self.eol_comments_re = re.compile(self.eol_comments)
 
     @classmethod
     def new(


### PR DESCRIPTION
Note: This is untested and I don't have time/energy to do any more on this, so if no one wants to wrap it up, feel free to close it.

Noticed this while profiling ics-py which felt really slow (even considering large ics files and it being python).

Would speed up https://github.com/ics-py/ics-py ~~3%~~ ~7% so not that much, but maybe worth a few line changes.

![image](https://github.com/neogeny/TatSu/assets/72201/7a13117c-5709-40ab-87d1-6df856cb35c9) (the 4 first call-sites are related to the comment regexs)

(github refuse to upload the py-spy profile..)