### PR TITLE
Fix non-thread-safe access of globals()

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -16,6 +16,7 @@ features, bug reports, bug fixes, or suggestions:
     `David Röthlisberger`_,
     `David Sanders`_,
     `Dmytro Ivanov`_,
+    `Ehsan Kia`_,
     `Felipe`_,
     `Franck Pommereau`_,
     `Franklin Lee`_,

--- a/docs/links_contributors.rst
+++ b/docs/links_contributors.rst
@@ -11,6 +11,7 @@
 .. _David Röthlisberger: https://bitbucket.org/drothlis/
 .. _David Sanders: https://github.com/davesque
 .. _Dmytro Ivanov: https://bitbucket.org/jimon
+.. _Ehsan Kia: https://github.com/ehsankia
 .. _Felipe: https://github.com/fcoelho
 .. _Franck Pommereau: https://github.com/fpom
 .. _Franklin Lee: https://bitbucket.org/leewz

--- a/tatsu/grammars.py
+++ b/tatsu/grammars.py
@@ -73,7 +73,8 @@ class Model(Node):
     def classes():
         return [
             c
-            for c in globals().values()
+            # Copy globals() before iterating to be thread-safe.
+            for c in globals().copy().values()
             if isinstance(c, type) and issubclass(c, Model)
         ]
 


### PR DESCRIPTION
globals().values() creates an iterator. If the thread changes in the middle of the comprehension and the globals dict is modified, we end up with the following error:

```
RuntimeError: dictionary changed size during iteration
```

To avoid that, we make a copy and iterate over that, to avoid concurrency issues.