### PR TITLE
Add missing license text for markdown_parser.leg

### DIFF
--- a/examples/markdown/grammar/LICENSE
+++ b/examples/markdown/grammar/LICENSE
@@ -1,0 +1,88 @@
+markdown in c, implemented using PEG grammar
+Copyright (c) 2008-2011 John MacFarlane
+ODF output code (c) 2011 Fletcher T. Penney
+
+peg-markdown is released under both the GPL and MIT licenses.
+You may pick the license that best fits your needs.
+
+The GPL
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+peg-0.1.4 (included for convenience - http://piumarta.com/software/peg/)
+
+Copyright (c) 2007 by Ian Piumarta
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the 'Software'),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, provided that the above copyright notice(s) and this
+permission notice appear in all copies of the Software.  Acknowledgement
+of the use of this Software in supporting documentation would be
+appreciated but is not required.
+
+THE SOFTWARE IS PROVIDED 'AS IS'.  USE ENTIRELY AT YOUR OWN RISK.
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+my_getopt (included for convenience - http://www.geocities.com/bsittler/) 
+
+Copyright 1997, 2000, 2001, 2002, 2006, Benjamin Sittler
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+


### PR DESCRIPTION
The file `examples/markdown/grammar/markdown_parser.leg` is copied from https://github.com/jgm/peg-markdown/blob/0.4.14/markdown_parser.leg, and it contains the following notice.

https://github.com/neogeny/TatSu/blob/68ed4a80da913cfb498e42a0ff63181a1a892ebf/examples/markdown/grammar/markdown_parser.leg#L4-L14

However the actual copyright and license notice for the `MIT` option are missing, even though the MIT license requires them to be redistributed. Similarly, the license notice for the `GPL-2.0-or-later` option is missing.

To remedy these problems, this PR includes a copy of https://github.com/jgm/peg-markdown/raw/refs/tags/0.4.14/LICENSE. The parts about `peg-0.1.4` and `my_getopt` are not relevant, as the corresponding files from https://github.com/jgm/peg-markdown are not included here.