### PR TITLE
Use temp directory instead of cwd for test storage

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -7,6 +7,7 @@ The following, among others, have contributed to |TatSu| with
 features, bug reports, bug fixes, or suggestions:
 
     `Alberto Berti`_,
+    `Andrzej Fiedukowicz`_,
     `Andy Wright`_,
     `Basel Shishani`_,
     `Benjamin Beasley`_,

--- a/docs/links_contributors.rst
+++ b/docs/links_contributors.rst
@@ -1,5 +1,6 @@
 
 .. _Alberto Berti: https://github.com/azazel75
+.. _Andrzej Fiedukowicz: https://github.com/fiedukow
 .. _Andy Wright: https://github.com/acw1251
 .. _Basel Shishani: https://bitbucket.org/basel-shishani
 .. _Basel Shishani: https://bitbucket.org/basel-shishani


### PR DESCRIPTION
In `test_36_unichars` we are writing local python file and them import it for testing purposes.

So far this was done in a local directory (current working dir), but this is not ideal, as it might not be on a writable filesystem. For that reason it seems better to use a temporary directory, that is much more commonly provided in a writable form.

This PR proposes that shift.