### PR TITLE
Fix generated rule keyword parameters

### DIFF
--- a/tatsu/contexts/decorator/rule.py
+++ b/tatsu/contexts/decorator/rule.py
@@ -28,6 +28,6 @@ def rule(*args: Any, **kwargs: Any) -> Callable:
         return __rule_wrapper(func)
 
     def decorator(func: Callable) -> Callable[[Any, Ctx], Any]:
-        return __rule_wrapper(func, *args, *kwargs)
+        return __rule_wrapper(func, *args, **kwargs)
 
     return decorator

--- a/tests/grammar/parameter_test.py
+++ b/tests/grammar/parameter_test.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: BSD-4-Clause
 from __future__ import annotations
 
+import builtins
 import contextlib
 import pathlib
 import sys
 import tempfile
+import types
 import unittest
 
 from tatsu.boot import TatSuParserGenerator
@@ -57,7 +59,7 @@ class ParameterTests(unittest.TestCase):
                 assert_equal('+', p4)
                 return ast
 
-            def rule_keyword(self, ast, k1, k2, k3, k4):
+            def rule_keywords(self, ast, k1, k2, k3, k4):
                 assert_equal('ABC', k1)
                 assert_equal(123, k2)
                 assert_equal('=', k3)
@@ -112,7 +114,13 @@ class ParameterTests(unittest.TestCase):
         semantics = TC36Semantics()
         ast = model.parse('a b c', semantics=semantics)
         self.assertEqual(['a', 'b', 'c'], ast)
-        pythongen(model)
+        code = pythongen(model)
+        module = types.ModuleType('tc36params')
+        module.__file__ = '<tc36params>'
+        exec(builtins.compile(code, module.__file__, 'exec'), module.__dict__)
+        parser = module.RuleArgumentsParser()
+        ast = parser.parse('a b c', semantics=semantics, parseinfo=False)
+        self.assertEqual(['a', 'b', 'c'], ast)
 
     def test_36_unichars(self):
         grammar = """


### PR DESCRIPTION
Fixes #427.\n\nGenerated parsers were receiving rule keyword parameter names as positional argument values because the rule decorator expanded the keyword dict with `*kwargs` instead of forwarding it with `**kwargs`. This keeps generated rule metadata equivalent to the model parser.\n\nAlso extends the parameter regression test to execute the generated parser path, including keyword parameters.\n\nValidation:\n- `uv run --quiet --python 3.14 --group test pytest --tb=short tests/grammar/parameter_test.py::ParameterTests::test_36_param_combinations tests/grammar/parameter_test.py::ParameterTests::test_numbers_and_unicode tests/parser_equivalence_test.py tests/z_bootstrap_test.py -q`\n- `env -u NO_COLOR TERM=xterm-256color uv run --quiet --python 3.14 --group test pytest -n auto --tb=short --no-header '--ignore-glob=tests/z*' tests`\n- `env -u NO_COLOR TERM=xterm-256color uv run --quiet --python 3.14 --group test pytest --tb=short --no-header tests/z_bootstrap_test.py`\n- `env -u NO_COLOR TERM=xterm-256color uv run --quiet --python 3.14 --group test ruff check -q --preview tatsu tests examples`\n- `env -u NO_COLOR TERM=xterm-256color uv run --quiet --python 3.14 --group test ruff format --check tatsu tests examples scripts ng`\n- `uv run --quiet --python 3.14 --group test python -m compileall -q tatsu tests`\n- `git diff --check`